### PR TITLE
Make pom-file kwarg optional in aether/install function

### DIFF
--- a/src/main/clojure/cemerick/pomegranate/aether.clj
+++ b/src/main/clojure/cemerick/pomegranate/aether.clj
@@ -284,10 +284,11 @@ kwarg to the repository kwarg.
         jar-artifact (-> (DefaultArtifact. (coordinate-string coordinates))
                          (.setFile jar-file))
         pom-artifact (-> (SubArtifact. jar-artifact "" "pom")
-                         (.setFile pom-file))]
-      (.install system session (doto (InstallRequest.)
-                      (.addArtifact jar-artifact)
-                      (.addArtifact pom-artifact)))))
+                         (.setFile pom-file))
+        inst-request (doto (InstallRequest.) (.addArtifact jar-artifact))]
+      (.install system session (if pom-file (doto inst-request
+                                              (.addArtifact pom-artifact))
+                                 inst-request))))
 
 (defn- dependency-graph
   ([node]


### PR DESCRIPTION
JAR files built with ANT, or proprietary JAR files (e.g. Oracle JDBC driver) do not have a corresponding `pom.xml` file. [lein-localrepo](https://github.com/kumarshantanu/lein-localrepo) installs such artifacts to the local Maven repository.

For Lein2, this functionality needs `pom-file` kwarg to be optional in `cemerick.pomegranate.aether/install`, which I have tested locally with a local build of Leiningen2. This pull request makes `pom-file` kwarg optional.
