### PR TITLE
Proxy Authentication kwargs not used

### DIFF
--- a/src/main/clojure/cemerick/pomegranate/aether.clj
+++ b/src/main/clojure/cemerick/pomegranate/aether.clj
@@ -160,9 +160,8 @@
          :as proxy} ]
   (if (and repo host port)
     (let [prx-sel (doto (DefaultProxySelector.)
-                    (.add (doto (Proxy. type host port nil)
-                            (set-authentication proxy)) 
-                      non-proxy-hosts)) 
+                    (.add (set-authentication (Proxy. type host port nil) proxy)
+                          non-proxy-hosts))
           prx (.getProxy prx-sel repo)]
       (.setProxy repo prx))
     repo))


### PR DESCRIPTION
Proxy.setAuthentication returns a new proxy object, so the auth
configuration was never used.
