### PR TITLE
Add .travis.yml that tests against 3 JDKs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: clojure
+install: mvn install --quiet -DskipTests=true
+script: mvn test
+jdk:
+  - openjdk7
+  - openjdk6
+  - oraclejdk7


### PR DESCRIPTION
Because Pomegranate is a dependency of Leiningen, I'd suggest we should have CI for it, testing against multiple JDKs.

The rest of the setup process is [documented in Travis' Getting Started guide](http://about.travis-ci.org/docs/user/getting-started/)
