### PR TITLE
Accept :mirrors argument to install and resolve-dependencies. Fixes #29.

### DIFF
--- a/src/test/clojure/cemerick/pomegranate/aether_test.clj
+++ b/src/test/clojure/cemerick/pomegranate/aether_test.clj
@@ -68,6 +68,15 @@
     (is (= (.getAbsolutePath (io/file tmp-dir "local-repo" "javax" "servlet" "servlet-api" "2.5" "servlet-api-2.5.jar"))
            (.getAbsolutePath (first (aether/dependency-files deps)))))))
 
+(deftest resolve-deps-with-mirror
+  (let [deps (aether/resolve-dependencies :repositories test-remote-repo
+                                          :coordinates '[[javax.servlet/servlet-api "2.5"]]
+                                          :mirrors {"uk" {:url "http://uk.maven.org/maven2" :mirror-of "central"}}
+                                          :local-repo tmp-local-repo-dir)]
+    (is (= 1 (count deps)))
+    (is (= (.getAbsolutePath (io/file tmp-dir "local-repo" "javax" "servlet" "servlet-api" "2.5" "servlet-api-2.5.jar"))
+           (.getAbsolutePath (first (aether/dependency-files deps)))))))
+
 (deftest resolve-deps
   (let [deps (aether/resolve-dependencies :repositories test-repo
                                           :coordinates '[[demo/demo "1.0.0"]]


### PR DESCRIPTION
Assuming it's fine to ignore `:mirrors` in `deploy` since it shouldn't need to resolve anything, but the other callers of `repository-session` (`install` and `resolve-dependencies`) now honor it.

Accepts everything Aether exposes (`name`, `url`, `mirror-of`, `type`, `repo-manager`, and `mirror-of-types`) but doesn't document the type arguments since Aether doesn't explain them.
