### PR TITLE
Allow unmanaged dependencies

### DIFF
--- a/src/main/clojure/cemerick/pomegranate/aether.clj
+++ b/src/main/clojure/cemerick/pomegranate/aether.clj
@@ -16,7 +16,8 @@
            (org.sonatype.aether.collection CollectRequest)
            (org.sonatype.aether.resolution DependencyRequest ArtifactRequest)
            (org.sonatype.aether.util.graph PreorderNodeListGenerator)
-           (org.sonatype.aether.util.artifact DefaultArtifact SubArtifact)
+           (org.sonatype.aether.util.artifact DefaultArtifact SubArtifact
+                                              ArtifactProperties)
            (org.sonatype.aether.deployment DeployRequest)
            (org.sonatype.aether.installation InstallRequest)
            (org.sonatype.aether.util.version GenericVersionScheme)))
@@ -221,10 +222,15 @@
                               :or {scope "compile"
                                    optional false}}
     :as dep-spec]]
-  (Dependency. (DefaultArtifact. (coordinate-string dep-spec))
-               scope
-               optional
-               (map (comp exclusion normalize-exclusion-spec) exclusions)))
+  (let [a (DefaultArtifact. (coordinate-string dep-spec))
+        file (:file (meta dep-spec))]
+    (Dependency. (if file
+                     (.setProperties a {ArtifactProperties/LOCAL_PATH
+                                        (.getPath file)})
+                     a)
+                 scope
+                 optional
+                 (map (comp exclusion normalize-exclusion-spec) exclusions))))
 
 (declare dep-spec*)
 

--- a/src/test/clojure/cemerick/pomegranate/aether_test.clj
+++ b/src/test/clojure/cemerick/pomegranate/aether_test.clj
@@ -97,6 +97,17 @@
     (is (= 1 (count (filter #(file-path-eq % (io/file tmp-dir "local-repo" "demo" "demo2" "1.0.0" "demo2-1.0.0.jar"))
                             files))))))
 
+(deftest resolve-deps-with-deps
+  (let [deps (aether/resolve-dependencies
+              :repositories {}
+              :coordinates [(with-meta '[demo "1.0.0"]
+                               {:file (io/file "test-repo" "demo" "demo"
+                                               "1.0.0" "demo-1.0.0.jar")})]
+              :local-repo tmp-local-repo-dir)
+        files (aether/dependency-files deps)]
+    (is (= 1 (count files)))
+    (is (= nil (:file (meta (first files)))))))
+
 (deftest resolve-deps-with-exclusions
   (let [deps (aether/resolve-dependencies :repositories test-repo
                                           :coordinates


### PR DESCRIPTION
Aether allows unmanaged dependencies to go through the CollectRequest
by setting a property on the Artifact.  This is similiar to the maven
"system" scope.  One use case is for tools.jar that ships with the jvm.
Unfortunatly, this does make it easy to add dependencies that will
not exist on other systems.

It is implemented by using :file metadata on the coordinates to
be consistent with other api methods.
