### PR TITLE
Added find-resources

### DIFF
--- a/src/main/clojure/cemerick/pomegranate.clj
+++ b/src/main/clojure/cemerick/pomegranate.clj
@@ -114,9 +114,21 @@ unless you are extending a type to this protocol."
 
    (get-classpath (drop 2 (classloader-hierarchy)))"
   ([classloaders]
-    []
     (->> (reverse classloaders)
       (mapcat #(when (instance? URLClassLoader %) (.getURLs %)))
       (map str)))
   ([] (get-classpath (classloader-hierarchy))))
 
+(defn find-resources
+  "Returns a sequence of URLs representing all of the resources of the
+   specified name on the effective classpath. This can be useful for
+   finding name collisions among items on the classpath. In most
+   circumstances, the first of the returned sequence will be the same
+   as what clojure.java.io/resource returns."
+  ([classloaders resource-name]
+     (->> (reverse classloaders)
+          (mapcat #(when (instance? URLClassLoader %)
+                     (enumeration-seq
+                      (.findResources ^URLClassLoader % resource-name))))
+          (map str)))
+  ([resource-name] (find-resources (classloader-hierarchy) resource-name)))


### PR DESCRIPTION
When tracking down a library version problem yesterday, we found it useful to be able to look at all the jars on the classpath that included a particular .clj file.  This allowed us to see we were loading it from a different .jar than we expected.  Pomegranate seems a natural place to have a function that makes this easy.

For example, here's what I get when I nrepl-jack-in from the pomegranate project itself:

(find-resources "clojure/core.clj")
;=> ("jar:file:/home/chouser/.lein/self-installs/leiningen-2.0.0-preview8-standalone.jar!/clojure/core.clj" "jar:file:/home/chouser/.m2/repository/org/clojure/clojure/1.4.0/clojure-1.4.0.jar!/clojure/core.clj" "jar:file:/home/chouser/.m2/repository/org/clojure/clojure/1.3.0/clojure-1.3.0.jar!/clojure/core.clj")
