### PR TITLE
Update to latest dynapath

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
           <groupId>org.tcrawley</groupId>
           <artifactId>dynapath</artifactId>
-          <version>0.2.1</version>
+          <version>0.2.3</version>
         </dependency>
         
         <!-- wagons for dependency resolution -->


### PR DESCRIPTION
0.2.3 has a fix that prevents pomegranate from modifying the boot
class loader.

The ExtClassLoader is a URLClassLoader, but shouldn't be given jars
containing classes that it has already loaded via another url.

Apparently the code in the old pomegranate protocol implementation
that extended ExtClassLoader wasn't really a no-op. 

0.2.3 isn't yet on central - I'll comment here when it lands.
