### PR TITLE
Resolving reflection warnings

### DIFF
--- a/src/main/clojure/cemerick/pomegranate/aether.clj
+++ b/src/main/clojure/cemerick/pomegranate/aether.clj
@@ -147,7 +147,7 @@
     (update-policies (:update policy-settings :daily))
     (checksum-policies (:checksum policy-settings :fail))))
 
-(defn- set-policies
+(defn- set-policies ^RemoteRepository
   [^RemoteRepository repo settings]
   (doto repo
     (.setPolicy true (policy settings (:snapshots settings true)))
@@ -155,12 +155,12 @@
 
 (defn- set-authentication
   "Calls the setAuthentication method on obj"
-  [^Proxy obj {:keys [^String username ^String password ^String passphrase ^String private-key-file] :as settings}]
+  [obj {:keys [^String username ^String password ^String passphrase ^String private-key-file] :as settings}]
   (if (or username password private-key-file passphrase)
     (.setAuthentication obj (Authentication. username password private-key-file passphrase))
     obj))
 
-(defn- set-proxy
+(defn- set-proxy ^RemoteRepository
   [^RemoteRepository repo {:keys [type host port non-proxy-hosts ]
          :or {type "http"}
          :as proxy} ]


### PR DESCRIPTION
I've been experiencing exceptions when using derkork's intellij-leiningen-plugin, which uses leiningen (and consequently pomegranate) for dependency resolution.

Our internal repository requires authentication with both certificates and private keys, and while this works from leiningen it doesn't work from inside IntelliJ (unless I'm running the plugin debugger, you know how these things go :-).

The exception (see below) seems to be caused by an ambiguous call to the org.sonatype.aether.repository.Authentication constructor from 'set-authentication'. I'm guessing that if both password and passphase are nil then the appropriate constructor to use can't be determined. I haven't been able to inspect the actual inputs because I can't reproduce the error in a debugger.

This pull requests contains three patch:
- the first addresses the issue I raised in #61.
- the second addresses this specific issue by adding type-hints for all four parameters (String, rather than byte[]). Leiningen at least seems to call this function with strings. You may prefer to add a dynamic check if you think it's desirable to be able to use both byte[] passwords and String passwords.
- the third patch adds type hints for almost all reflection warnings generated by the clojure compiler (the one remaining warning can't be resolved with a type hint as it could dispatch to similar methods in different classes).

Hopefully some or all of these are useful.

```
Exception:
    java.lang.IllegalArgumentException: No matching ctor found for class org.sonatype.aether.repository.Authentication
at clojure.lang.Reflector.invokeConstructor(Reflector.java:183)
at cemerick.pomegranate.aether$set_authentication.invoke(aether.clj:159)
at cemerick.pomegranate.aether$make_repository.invoke(aether.clj:179)
at cemerick.pomegranate.aether$resolve_dependencies$fn__148.invoke(aether.clj:541)
at clojure.core$map$fn__4087.invoke(core.clj:2432)
at clojure.lang.LazySeq.sval(LazySeq.java:42)
at clojure.lang.LazySeq.seq(LazySeq.java:60)
at clojure.lang.RT.seq(RT.java:473)
at clojure.lang.LazilyPersistentVector.create(LazilyPersistentVector.java:31)
at clojure.core$vec.invoke(core.clj:346)
at cemerick.pomegranate.aether$resolve_dependencies.doInvoke(aether.clj:541)
at clojure.lang.RestFn.invoke(RestFn.java:1523)
at leiningen.core.classpath$get_dependencies.doInvoke(classpath.clj:122)
at clojure.lang.RestFn.invoke(RestFn.java:425)
at leiningen.core.classpath$dependency_hierarchy.invoke(classpath.clj:157)
at de.janthomae.leiningenplugin.leiningen.LeiningenAPI$_loadDependencies.invoke(LeiningenAPI.clj:51)
```
