### PR TITLE
Add exclusion to org.sonatype.aether/aether-connector-wagon

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,12 @@
             <groupId>org.sonatype.aether</groupId>
             <artifactId>aether-connector-wagon</artifactId>
             <version>${aetherVersion}</version>
+            <exclusions>
+              <exclusion>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-utils</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
@@ -72,7 +78,7 @@
           <artifactId>dynapath</artifactId>
           <version>0.2.3</version>
         </dependency>
-        
+
         <!-- wagons for dependency resolution -->
         <dependency>
           <groupId>org.apache.maven.wagon</groupId>


### PR DESCRIPTION
Exclude [org.codehaus.plexus/plexus-utils "2.0.7"] based on report
generated by lein deps :tree

[com.cemerick/pomegranate "0.2.0"] -> [org.sonatype.aether/aether-connector-wagon "1.13.1"] -> [org.codehaus.plexus/plexus-utils "2.0.7"]
 overrides
[com.cemerick/pomegranate "0.2.0"] -> [org.apache.maven.wagon/wagon-provider-api "2.2"] -> [org.codehaus.plexus/plexus-utils "3.0"]
 and
[com.cemerick/pomegranate "0.2.0"] -> [org.apache.maven.wagon/wagon-http "2.2"] -> [org.apache.maven.wagon/wagon-provider-api "2.2"] -> [org.codehaus.plexus/plexus-utils "3.0"]
 and
[com.cemerick/pomegranate "0.2.0"] -> [org.apache.maven.wagon/wagon-http "2.2"] -> [org.apache.maven.wagon/wagon-http-shared4 "2.2"] -> [org.apache.maven.wagon/wagon-provider-api "2.2"] -> [org.codehaus.plexus/plexus-utils "3.0"]
