### PR TITLE
Fixed #61: resolve-artifacts* type error when using a :files map

### DIFF
--- a/src/main/clojure/cemerick/pomegranate/aether.clj
+++ b/src/main/clojure/cemerick/pomegranate/aether.clj
@@ -575,13 +575,10 @@ kwarg to the repository kwarg.
                   :mirror-selector mirror-selector})
         deps (->> coordinates
                   (map #(if-let [local-file (get files %)]
-                          (.setArtifact
-                           (artifact %)
-                           (-> (artifact %)
-                               .getArtifact
-                               (.setProperties
-                                {ArtifactProperties/LOCAL_PATH
-                                 (.getPath (io/file local-file))})))
+                          (-> (artifact %)
+                              (.setProperties
+                               {ArtifactProperties/LOCAL_PATH
+                                (.getPath (io/file local-file))}))
                           (artifact %)))
                   vec)
         repositories (vec (map #(let [repo (make-repository % proxy)]

--- a/src/test/clojure/cemerick/pomegranate/aether_test.clj
+++ b/src/test/clojure/cemerick/pomegranate/aether_test.clj
@@ -65,6 +65,10 @@
     (is (= deps (aether/resolve-artifacts
                  :coordinates deps :retrieve false
                  :local-repo tmp-local-repo-dir)))
+    (is (= 1 (count (aether/resolve-artifacts
+                     :coordinates '[[demo "1.0.0"]] :retrieve false
+                     :files {'[demo "1.0.0"] (io/file "test-repo" "demo" "demo" "1.0.0" "demo-1.0.0.jar")}
+                     :local-repo tmp-local-repo-dir))))
     (is (not (some #(-> % .getName (.endsWith ".jar"))
                    (file-seq tmp-local-repo-dir))))
     (doseq [dep (aether/resolve-artifacts


### PR DESCRIPTION
resolve-artifacts\* accepts a map of known artifacts to file names but treats them as dependencies instead of artifacts. This causes a type error at runtime if a :files map is actually provided. This patch corrects the error (likely from copy-paste, see #61) and adds a test for resolving artifacts against a :files map.
