### PR TITLE
Properly escape URLs added to the classpath.

### DIFF
--- a/src/main/clojure/cemerick/pomegranate.clj
+++ b/src/main/clojure/cemerick/pomegranate.clj
@@ -45,7 +45,7 @@
    to add that path to the right classloader (with the search rooted at the current
    thread's context classloader)."
   ([jar-or-dir classloader]
-     (if-not (dp/add-classpath-url classloader (.toURL (io/file jar-or-dir)))
+     (if-not (dp/add-classpath-url classloader (.toURL (.toURI (io/file jar-or-dir))))
        (throw (IllegalStateException. (str classloader " is not a modifiable classloader")))))
   ([jar-or-dir]
     (let [classloaders (classloader-hierarchy)]


### PR DESCRIPTION
The function `.toURL` in java.File has been deprecated since 1.4 as it does not properly escape special characters. (More info in the [Oracle Bug Database](http://bugs.java.com/bugdatabase/view_bug.do?bug_id=6179468)). The recommended way to handle special characters is by converting the String to a URI first, then to a URL.

This pull request will fix the problems presented in technomancy/leiningen#1447.
