### PR TITLE
Also download signature checksums

### DIFF
--- a/src/main/clojure/cemerick/pomegranate/aether.clj
+++ b/src/main/clojure/cemerick/pomegranate/aether.clj
@@ -138,16 +138,20 @@
 
 (defn repository-session
   [{:keys [repository-system local-repo offline? transfer-listener mirror-selector]}]
-  (let [session (org.apache.maven.repository.internal.MavenRepositorySystemUtils/newSession)]
-    (doto session
-      (.setLocalRepositoryManager (.newLocalRepositoryManager
-                                   repository-system
-                                   session
-                                   (LocalRepository.
-                                    (io/file (or local-repo default-local-repo)))))
-      (.setMirrorSelector mirror-selector)
-      (.setOffline (boolean offline?))
-      (.setTransferListener (construct-transfer-listener transfer-listener)))))
+  (let [session (org.apache.maven.repository.internal.MavenRepositorySystemUtils/newSession)
+        session (doto session
+                  (.setLocalRepositoryManager (.newLocalRepositoryManager
+                                               repository-system
+                                               session
+                                               (LocalRepository.
+                                                (io/file (or local-repo default-local-repo)))))
+                  (.setMirrorSelector mirror-selector)
+                  (.setOffline (boolean offline?))
+                  (.setTransferListener (construct-transfer-listener transfer-listener)))]
+    (if (contains? (.getConfigProperties session) "aether.checksums.forSignature")
+      session
+      (doto session
+        (.setConfigProperty "aether.checksums.forSignature" true)))))
 
 (def update-policies {:daily RepositoryPolicy/UPDATE_POLICY_DAILY
                       :always RepositoryPolicy/UPDATE_POLICY_ALWAYS

--- a/src/test/clojure/cemerick/pomegranate/aether_test.clj
+++ b/src/test/clojure/cemerick/pomegranate/aether_test.clj
@@ -321,8 +321,6 @@
      :local-repo tmp-local-repo-dir))
   (is (= 3 (count (.list (io/file tmp-local-repo-dir "group" "artifact" "1.0.0"))))))
 
-(java.lang.System/setProperty "aether.checksums.forSignature" "true")
-
 (deftest deploy-artifacts
   (aether/deploy-artifacts
    :artifacts '[[demo "1.0.0"]


### PR DESCRIPTION
The proposed change tweaks the session configuration, such that signature checksums (files ending in `.asc.sha1`) are downloaded as well. This fixes #113, and downstream technomancy/leiningen#2567.

Details: We are currently using the (default) legacy repository layout instance that intentionally does not download signature checksums. To use the repository layout where signature checksums _are_ downloaded, the named configuration property `aether.checksums.forSignature` must be enabled.

In my view, this is a change we will have to make. In addition, we should consider going back from the `:fail` checksum policy to `:warn`, since the `:fail` policy causes checksum verification of most artefacts (all of Clojure core) to fail – that is, undo #28. This is independent of the change proposed here.
