### PR TITLE
Fix dependency conflict after recent Maven resolver version bumps

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,9 @@
 {:paths ["src/main/clojure"]
- :deps {org.apache.maven/maven-resolver-provider {:mvn/version "3.6.0"}
+ :deps {org.apache.maven/maven-resolver-provider {:mvn/version "3.6.1"}
+        org.apache.maven.resolver/maven-resolver-api {:mvn/version "1.3.3"}
+        org.apache.maven.resolver/maven-resolver-spi {:mvn/version "1.3.3"}
+        org.apache.maven.resolver/maven-resolver-util {:mvn/version "1.3.3"}
+        org.apache.maven.resolver/maven-resolver-impl {:mvn/version "1.3.3"}
         org.apache.maven.resolver/maven-resolver-transport-file {:mvn/version "1.3.3"}
         org.apache.maven.resolver/maven-resolver-transport-http {:mvn/version "1.3.3"}
         org.apache.maven.resolver/maven-resolver-transport-wagon {:mvn/version "1.3.3"}
@@ -8,7 +12,8 @@
         org.apache.maven.wagon/wagon-provider-api {:mvn/version "3.3.2"}
         org.apache.maven.wagon/wagon-http {:mvn/version "3.3.2"}
         org.apache.maven.wagon/wagon-ssh {:mvn/version "3.3.2"}
-        org.apache.httpcomponents/httpclient {:mvn/version "4.5.7"}}
+        org.apache.httpcomponents/httpclient {:mvn/version "4.5.8"}
+        org.apache.httpcomponents/httpcore {:mvn/version "4.4.11"}}
 
  :aliases {:test {:extra-paths ["src/test/clojure"]
                   :extra-deps {com.cognitect/test-runner {:git/url "https://github.com/cognitect-labs/test-runner.git"

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
     <properties>
         <clojure.version>1.3.0</clojure.version>
-        <mavenVersion>3.6.0</mavenVersion>
+        <mavenVersion>3.6.1</mavenVersion>
         <resolverVersion>1.3.3</resolverVersion>
         <wagonVersion>3.3.2</wagonVersion>
     </properties>
@@ -40,6 +40,26 @@
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-resolver-provider</artifactId>
             <version>${mavenVersion}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-api</artifactId>
+            <version>${resolverVersion}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-spi</artifactId>
+            <version>${resolverVersion}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-util</artifactId>
+            <version>${resolverVersion}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-impl</artifactId>
+            <version>${resolverVersion}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.resolver</groupId>
@@ -88,7 +108,12 @@
         <dependency>
           <groupId>org.apache.httpcomponents</groupId>
           <artifactId>httpclient</artifactId>
-          <version>4.5.7</version>
+          <version>4.5.8</version>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpcore</artifactId>
+          <version>4.4.11</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Version 3.6.0 of Maven Resolver Provider, which was recently introduced (a788dec827511063ebdb9b8b44174841519d043b), contains transitive dependencies that conflict with each other. This breaks Pomegranate consumers like Leiningen. The conflicts are resolved in version 3.6.1 of this dependency.

The proposed change bumps Maven Resolver Provider to 3.6.1. It also adds four ‘used but undeclared’ Maven resolver dependencies that are directly used in Pomegranate, and so should be declared as dependencies. Finally, it pins the transitive dependency `org.apache.httpcomponents/httpcore`, again to prevent a version conflict.

I have verified that this fixes the breakage in the Leiningen build, so this fixes #115.
