### PR TITLE
Type hint to remove reflection warnings

### DIFF
--- a/src/main/clojure/cemerick/pomegranate.clj
+++ b/src/main/clojure/cemerick/pomegranate.clj
@@ -17,8 +17,8 @@
 
   The method-name is given a symbol or a keyword (something Named)."
   [klass method-name params obj & args]
-  (-> klass (.getDeclaredMethod (name method-name)
-                                (into-array Class params))
+  (-> ^Class klass (.getDeclaredMethod (name method-name)
+                                       (into-array Class params))
     (doto (.setAccessible true))
     (.invoke obj (into-array Object args))))
 
@@ -29,7 +29,7 @@
   ([] (classloader-hierarchy (.. Thread currentThread getContextClassLoader)))
   ([tip]
     (->> tip
-      (iterate #(.getParent %))
+      (iterate #(.getParent ^ClassLoader %))
       (take-while boolean))))
 
 (defn modifiable-classloader?

--- a/src/main/clojure/cemerick/pomegranate/aether.clj
+++ b/src/main/clojure/cemerick/pomegranate/aether.clj
@@ -4,7 +4,7 @@
             clojure.set
             [clojure.string :as str]
             clojure.stacktrace)
-  (:import (org.eclipse.aether RepositorySystem)
+  (:import (org.eclipse.aether RepositorySystem RepositorySystemSession)
            (org.eclipse.aether.transport.wagon WagonTransporterFactory
                                                WagonProvider)
            (org.eclipse.aether.transport.file FileTransporterFactory)
@@ -17,8 +17,8 @@
                                           MirrorSelector)
            (org.eclipse.aether.util.repository DefaultProxySelector AuthenticationBuilder)
            (org.eclipse.aether.graph Dependency Exclusion DependencyNode)
-           (org.eclipse.aether.collection CollectRequest)
-           (org.eclipse.aether.resolution DependencyRequest ArtifactRequest
+           (org.eclipse.aether.collection CollectRequest CollectResult)
+           (org.eclipse.aether.resolution DependencyRequest DependencyResult ArtifactRequest
                                           ArtifactResult VersionRequest)
            (org.eclipse.aether.artifact DefaultArtifact ArtifactProperties)
            (org.eclipse.aether.util.artifact SubArtifact)
@@ -106,7 +106,7 @@
                  (when (< 70 (+ 10 (count name) (count repository)))
                    (println) (print "    "))
                  (println (case method :get "from" :put "to") repository))
-      (:corrupted :failed) (when error (println (.getMessage error)))
+      (:corrupted :failed) (when error (println (.getMessage ^Exception error)))
       nil)))
 
 (defn- repository-system
@@ -138,10 +138,9 @@
 
 (defn repository-session
   [{:keys [repository-system local-repo offline? transfer-listener mirror-selector]}]
-  (let [session (org.apache.maven.repository.internal.MavenRepositorySystemUtils/newSession)
-        session (doto session
+  (let [session (doto (org.apache.maven.repository.internal.MavenRepositorySystemUtils/newSession)
                   (.setLocalRepositoryManager (.newLocalRepositoryManager
-                                               repository-system
+                                               ^RepositorySystem repository-system
                                                session
                                                (LocalRepository.
                                                 (io/file (or local-repo default-local-repo)))))
@@ -170,7 +169,7 @@
 
 (defn- set-policies
   [repo-builder settings]
-  (doto repo-builder
+  (doto ^RemoteRepository$Builder repo-builder
     (.setSnapshotPolicy (policy settings (:snapshots settings true)))
     (.setReleasePolicy (policy settings (:releases settings true)))))
 
@@ -178,14 +177,14 @@
   [{:keys [username password passphrase private-key-file] :as settings}]
   (-> (AuthenticationBuilder.)
       (.addUsername username)
-      (.addPassword password)
-      (.addPrivateKey private-key-file passphrase)
+      (.addPassword ^String password)
+      (.addPrivateKey ^String private-key-file ^String passphrase)
       .build))
 
 (defn- set-authentication
   [repo-builder {:keys [username password passphrase private-key-file] :as settings}]
   (if (or username password private-key-file passphrase)
-    (.setAuthentication repo-builder (authentication settings))
+    (.setAuthentication ^RemoteRepository$Builder repo-builder (authentication settings))
     repo-builder))
 
 (defn- set-proxy
@@ -196,9 +195,9 @@
     (let [prx-sel (doto (DefaultProxySelector.)
                     (.add (Proxy. type host port (authentication proxy))
                           non-proxy-hosts))
-          prx (.getProxy prx-sel (.build repo-builder))] ; ugg.
+          prx (.getProxy prx-sel (.build ^RemoteRepository$Builder repo-builder))] ; ugg.
       ;; Don't know how to get around "building" the repo for this
-      (.setProxy repo-builder prx))
+      (.setProxy ^RemoteRepository$Builder repo-builder prx))
     repo-builder))
 
 (defn make-repository
@@ -359,7 +358,7 @@
                   :local-repo local-repo
                   :offline? false
                   :transfer-listener transfer-listener})]
-    (.deploy system session
+    (.deploy ^RepositorySystem system session
              (doto (DeployRequest.)
                (.setArtifacts (vec (map (partial create-artifact files) (keys files))))
                (.setRepository (first (map #(make-repository % proxy) repository)))))))
@@ -378,7 +377,7 @@
                   :local-repo local-repo
                   :offline? false
                   :transfer-listener transfer-listener})]
-    (.install system session
+    (.install ^RepositorySystem system session
               (doto (InstallRequest.)
                 (.setArtifacts (vec (map (partial create-artifact files) (keys files))))))))
 
@@ -467,13 +466,13 @@ kwarg to the repository kwarg.
                 (update-in g [(dep-spec dep)]
                            clojure.set/union
                            (->> (.getChildren n)
-                             (map #(.getDependency %))
+                             (map #(.getDependency ^DependencyNode %))
                              (map dep-spec)
                              set))
                 g))
             {}
             (tree-seq (constantly true)
-                      #(seq (.getChildren %))
+                      #(seq (.getChildren ^DependencyNode %))
                       node))))
 
 (defn- mirror-selector-fn
@@ -610,25 +609,25 @@ kwarg to the repository kwarg.
                   :mirror-selector mirror-selector})
         deps (->> coordinates
                   (map #(if-let [local-file (get files %)]
-                          (-> (artifact %)
+                          (-> ^Artifact (artifact %)
                               (.setProperties
                                {ArtifactProperties/LOCAL_PATH
                                 (.getPath (io/file local-file))}))
                           (artifact %)))
                   vec)
         repositories (vec (map #(let [repo (make-repository % proxy)]
-                                  (-> session
+                                  (-> ^RepositorySystemSession session
                                       (.getMirrorSelector)
                                       (.getMirror repo)
                                       (or repo)))
                                repositories))]
     (if retrieve
       (.resolveArtifacts
-       system session (map #(ArtifactRequest. % repositories nil) deps))
+       ^RepositorySystem system session (map #(ArtifactRequest. % repositories nil) deps))
       (doall
        (for [dep deps]
          (.resolveVersion
-          system session (VersionRequest. dep repositories nil)))))))
+          ^RepositorySystem system session (VersionRequest. dep repositories nil)))))))
 
 (defn resolve-artifacts
   "Same as `resolve-artifacts*`, but returns a sequence of dependencies; each
@@ -700,8 +699,8 @@ kwarg to the repository kwarg.
   [files coordinates]
   (->> coordinates
        (map #(if-let [local-file (get files %)]
-              (.setArtifact (dependency %)
-                            (-> (dependency %)
+              (.setArtifact ^Dependency (dependency %)
+                            (-> ^Dependency (dependency %)
                                 .getArtifact
                                 (.setProperties {ArtifactProperties/LOCAL_PATH
                                                  (.getPath (io/file local-file))})))
@@ -797,18 +796,19 @@ kwarg to the repository kwarg.
         coordinates (merge-versions-from-managed-coords coordinates managed-coordinates)
         deps (coords->Dependencies files coordinates)
         managed-deps (coords->Dependencies files managed-coordinates)
-        collect-request (doto (CollectRequest. deps
-                                               managed-deps
+        collect-request (doto (CollectRequest. ^java.util.List deps
+                                               ^java.util.List managed-deps
+                                               ^java.util.List
                                                (vec (map #(let [repo (make-repository % proxy)]
-                                                            (-> session
+                                                            (-> ^RepositorySystemSession session
                                                                 (.getMirrorSelector)
                                                                 (.getMirror repo)
                                                                 (or repo)))
                                                          repositories)))
                           (.setRequestContext "runtime"))]
     (if retrieve
-      (.resolveDependencies system session (DependencyRequest. collect-request nil))
-      (.collectDependencies system session collect-request))))
+      (.resolveDependencies ^RepositorySystem system session (DependencyRequest. collect-request nil))
+      (.collectDependencies ^RepositorySystem system session collect-request))))
 
 (defn resolve-dependencies
   "Same as `resolve-dependencies*`, but returns a graph of dependencies; each
@@ -816,9 +816,14 @@ kwarg to the repository kwarg.
    the dependency's :file on disk.  Please refer to `resolve-dependencies*` for details
    on usage, or use it if you need access to Aether dependency resolution objects."
   [& args]
-  (-> (apply resolve-dependencies* args)
-    .getRoot
-    dependency-graph))
+  (let [result (apply resolve-dependencies* args)]
+    (if (instance? DependencyResult result)
+      (-> ^DependencyResult result
+          .getRoot
+          dependency-graph)
+      (-> ^CollectResult result
+          .getRoot
+          dependency-graph))))
 
 (defn dependency-files
   "Given a dependency graph obtained from `resolve-dependencies`, returns a seq of


### PR DESCRIPTION
When using this dependency with `*warn-on-reflect*` set, it produces a number of reflection warnings. I've added some type hints to fix them (as well as some simple logic in `resolve-dependencies` to select between two types).
```
Compiling namespace cemerick.pomegranate
Reflection warning, cemerick/pomegranate/aether.clj:109:49 - reference to field getMessage on java.lang.Object can't be resolved.
Reflection warning, cemerick/pomegranate/aether.clj:109:49 - reference to field getMessage on java.lang.Object can't be resolved.
Reflection warning, cemerick/pomegranate/aether.clj:143:35 - call to method newLocalRepositoryManager on java.lang.Object can't be resolved (no such method).
Reflection warning, cemerick/pomegranate/aether.clj:170:5 - call to method setSnapshotPolicy can't be resolved (target class is unknown).
Reflection warning, cemerick/pomegranate/aether.clj:171:5 - call to method setReleasePolicy can't be resolved (target class is unknown).
Reflection warning, cemerick/pomegranate/aether.clj:177:7 - call to method addPassword on org.eclipse.aether.util.repository.AuthenticationBuilder can't be resolved (argument types: java.lang.Object).
Reflection warning, cemerick/pomegranate/aether.clj:178:7 - call to method addPrivateKey can't be resolved (target class is unknown).
Reflection warning, cemerick/pomegranate/aether.clj:175:3 - reference to field build can't be resolved.
Reflection warning, cemerick/pomegranate/aether.clj:184:5 - call to method setAuthentication can't be resolved (target class is unknown).
Reflection warning, cemerick/pomegranate/aether.clj:195:34 - reference to field build can't be resolved.
Reflection warning, cemerick/pomegranate/aether.clj:197:7 - call to method setProxy can't be resolved (target class is unknown).
Reflection warning, cemerick/pomegranate/aether.clj:358:5 - call to method deploy can't be resolved (target class is unknown).
Reflection warning, cemerick/pomegranate/aether.clj:377:5 - call to method install can't be resolved (target class is unknown).
Reflection warning, cemerick/pomegranate/aether.clj:466:36 - reference to field getDependency can't be resolved.
Reflection warning, cemerick/pomegranate/aether.clj:472:29 - reference to field getChildren can't be resolved.
Reflection warning, cemerick/pomegranate/aether.clj:610:31 - call to method setProperties can't be resolved (target class is unknown).
Reflection warning, cemerick/pomegranate/aether.clj:617:39 - reference to field getMirrorSelector can't be resolved.
Reflection warning, cemerick/pomegranate/aether.clj:618:39 - call to method getMirror can't be resolved (target class is unknown).
Reflection warning, cemerick/pomegranate/aether.clj:622:7 - call to method resolveArtifacts can't be resolved (target class is unknown).
Reflection warning, cemerick/pomegranate/aether.clj:626:10 - call to method resolveVersion can't be resolved (target class is unknown).
Reflection warning, cemerick/pomegranate/aether.clj:626:10 - call to method resolveVersion can't be resolved (target class is unknown).
Reflection warning, cemerick/pomegranate/aether.clj:702:33 - reference to field getArtifact can't be resolved.
Reflection warning, cemerick/pomegranate/aether.clj:702:33 - call to method setProperties can't be resolved (target class is unknown).
Reflection warning, cemerick/pomegranate/aether.clj:699:15 - call to method setArtifact can't be resolved (target class is unknown).
Reflection warning, cemerick/pomegranate/aether.clj:800:65 - reference to field getMirrorSelector can't be resolved.
Reflection warning, cemerick/pomegranate/aether.clj:801:65 - call to method getMirror can't be resolved (target class is unknown).
Reflection warning, cemerick/pomegranate/aether.clj:796:31 - call to org.eclipse.aether.collection.CollectRequest ctor can't be resolved.
Reflection warning, cemerick/pomegranate/aether.clj:806:7 - call to method resolveDependencies can't be resolved (target class is unknown).
Reflection warning, cemerick/pomegranate/aether.clj:807:7 - call to method collectDependencies can't be resolved (target class is unknown).
Reflection warning, cemerick/pomegranate/aether.clj:815:3 - reference to field getRoot can't be resolved.
Reflection warning, cemerick/pomegranate.clj:20:13 - call to method getDeclaredMethod can't be resolved (target class is unknown).
Reflection warning, cemerick/pomegranate.clj:22:11 - call to method setAccessible can't be resolved (target class is unknown).
Reflection warning, cemerick/pomegranate.clj:23:5 - call to method invoke can't be resolved (target class is unknown).
Reflection warning, cemerick/pomegranate.clj:32:17 - reference to field getParent can't be resolved.
```