### PR TITLE
Update wagon libs from 3.3.2 -> 3.3.4

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -9,10 +9,10 @@
         org.apache.maven.resolver/maven-resolver-transport-wagon {:mvn/version "1.3.3"}
         org.apache.maven.resolver/maven-resolver-connector-basic {:mvn/version "1.3.3"}
         org.tcrawley/dynapath {:mvn/version "1.0.0"}
-        org.apache.maven.wagon/wagon-provider-api {:mvn/version "3.3.2"
+        org.apache.maven.wagon/wagon-provider-api {:mvn/version "3.3.4"
                                                    :exclusions [org.codehaus.plexus/plexus-utils]}
-        org.apache.maven.wagon/wagon-http {:mvn/version "3.3.2"}
-        org.apache.maven.wagon/wagon-ssh {:mvn/version "3.3.2"}
+        org.apache.maven.wagon/wagon-http {:mvn/version "3.3.4"}
+        org.apache.maven.wagon/wagon-ssh {:mvn/version "3.3.4"}
         org.apache.httpcomponents/httpclient {:mvn/version "4.5.8"}
         org.apache.httpcomponents/httpcore {:mvn/version "4.4.11"}}
 


### PR DESCRIPTION
The motivation for this is to restore display of the reason phrase
returned from the server. Clojars relies on this to convey more
context to the user when a deploy fails. Displaying it was removed in
wagon-http 3.2.0, and restored in 3.3.4 due to user complaint.

This should help resolve https://github.com/clojars/clojars-web/issues/774
once this is released and lein is updated to use the new version of
pomegranate.

The changelog for 3.3.2 -> 3.3.4 is
https://issues.apache.org/jira/browse/WAGON-541?jql=project%20%3D%20WAGON%20AND%20fixVersion%20in%20(3.3.3%2C%203.3.4)
with WAGON-541 being the relevant issue covering the reason phrase
changes.