### PR TITLE
Address all reflection warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,13 @@ shared: &shared
   steps:
     - checkout
 
+    - run:
+        name: Install Clojure
+        command: |
+          wget -nc https://download.clojure.org/install/linux-install-1.10.3.855.sh
+          chmod +x linux-install-1.10.3.855.sh
+          sudo ./linux-install-1.10.3.855.sh
+             
     # Download and cache dependencies
     # - restore_cache:
     #    keys:
@@ -30,6 +37,8 @@ shared: &shared
     #    key: v1-dependencies-{{ checksum "pom.xml" }}
     # run tests!
     - run: mvn test
+    # lint (especially reflection warnings)
+    - run: clojure -A:test:eastwood
 
 jobs:
   java-8:

--- a/deps.edn
+++ b/deps.edn
@@ -27,4 +27,8 @@
                                 "pomegranate.jar" "true"]}
            :install {:extra-deps {deps-deploy {:mvn/version "RELEASE"}}
                      :main-opts ["-m" "deps-deploy.deps-deploy" "install"
-                                 "pomegranate.jar" "true"]}}}
+                                 "pomegranate.jar" "true"]}
+
+           :eastwood {:main-opts  ["-m" "eastwood.lint" {:exclude-namespaces [cognitect.test-runner]
+                                                         :ignored-faults {:local-shadows-var {cemerick.pomegranate.aether true}}}]
+                      :extra-deps {jonase/eastwood {:mvn/version "0.9.2"}}}}}

--- a/src/main/clojure/cemerick/pomegranate.clj
+++ b/src/main/clojure/cemerick/pomegranate.clj
@@ -16,7 +16,7 @@
   obj is nil for static methods, the instance object otherwise.
 
   The method-name is given a symbol or a keyword (something Named)."
-  [klass method-name params obj & args]
+  [^Class klass method-name params obj & args]
   (-> klass (.getDeclaredMethod (name method-name)
                                 (into-array Class params))
     (doto (.setAccessible true))
@@ -29,7 +29,7 @@
   ([] (classloader-hierarchy (.. Thread currentThread getContextClassLoader)))
   ([tip]
     (->> tip
-      (iterate #(.getParent %))
+      (iterate #(.getParent ^ClassLoader %))
       (take-while boolean))))
 
 (defn modifiable-classloader?

--- a/src/main/clojure/cemerick/pomegranate/aether.clj
+++ b/src/main/clojure/cemerick/pomegranate/aether.clj
@@ -203,6 +203,7 @@
 
 (defn make-repository
   "Produces an Aether RemoteRepository instance from Pomegranate-style repository information"
+  ^RemoteRepository
   [[id settings] proxy]
   (let [settings-map (if (string? settings)
                        {:url settings}

--- a/src/main/clojure/cemerick/pomegranate/aether.clj
+++ b/src/main/clojure/cemerick/pomegranate/aether.clj
@@ -170,7 +170,7 @@
 
 (defn- set-policies
   [repo-builder settings]
-  (doto ^RemoteRepository$Builder repo-builder
+  (doto ^org.eclipse.aether.repository.RemoteRepository$Builder repo-builder
     (.setSnapshotPolicy (policy settings (:snapshots settings true)))
     (.setReleasePolicy (policy settings (:releases settings true)))))
 
@@ -185,7 +185,7 @@
 (defn- set-authentication
   [repo-builder {:keys [username password passphrase private-key-file] :as settings}]
   (if (or username password private-key-file passphrase)
-    (.setAuthentication ^RemoteRepository$Builder repo-builder (authentication settings))
+    (.setAuthentication ^org.eclipse.aether.repository.RemoteRepository$Builder repo-builder (authentication settings))
     repo-builder))
 
 (defn- set-proxy
@@ -196,14 +196,14 @@
     (let [prx-sel (doto (DefaultProxySelector.)
                     (.add (Proxy. type host port (authentication proxy))
                           non-proxy-hosts))
-          prx (.getProxy prx-sel (.build ^RemoteRepository$Builder repo-builder))] ; ugg.
+          prx (.getProxy prx-sel (.build ^org.eclipse.aether.repository.RemoteRepository$Builder repo-builder))] ; ugg.
       ;; Don't know how to get around "building" the repo for this
-      (.setProxy ^RemoteRepository$Builder repo-builder prx))
+      (.setProxy ^org.eclipse.aether.repository.RemoteRepository$Builder repo-builder prx))
     repo-builder))
 
 (defn make-repository
   "Produces an Aether RemoteRepository instance from Pomegranate-style repository information"
-  ^RemoteRepository
+  ^org.eclipse.aether.repository.RemoteRepository
   [[id settings] proxy]
   (let [settings-map (if (string? settings)
                        {:url settings}

--- a/src/main/clojure/cemerick/pomegranate/aether.clj
+++ b/src/main/clojure/cemerick/pomegranate/aether.clj
@@ -4,7 +4,7 @@
             clojure.set
             [clojure.string :as str]
             clojure.stacktrace)
-  (:import (org.eclipse.aether RepositorySystem)
+  (:import (org.eclipse.aether RepositorySystem RepositorySystemSession)
            (org.eclipse.aether.transport.wagon WagonTransporterFactory
                                                WagonProvider)
            (org.eclipse.aether.transport.file FileTransporterFactory)
@@ -17,8 +17,8 @@
                                           MirrorSelector)
            (org.eclipse.aether.util.repository DefaultProxySelector AuthenticationBuilder)
            (org.eclipse.aether.graph Dependency Exclusion DependencyNode)
-           (org.eclipse.aether.collection CollectRequest)
-           (org.eclipse.aether.resolution DependencyRequest ArtifactRequest
+           (org.eclipse.aether.collection CollectRequest CollectResult)
+           (org.eclipse.aether.resolution DependencyRequest DependencyResult ArtifactRequest
                                           ArtifactResult VersionRequest)
            (org.eclipse.aether.artifact DefaultArtifact ArtifactProperties)
            (org.eclipse.aether.util.artifact SubArtifact)
@@ -106,7 +106,7 @@
                  (when (< 70 (+ 10 (count name) (count repository)))
                    (println) (print "    "))
                  (println (case method :get "from" :put "to") repository))
-      (:corrupted :failed) (when error (println (.getMessage error)))
+      (:corrupted :failed) (when error (println (.getMessage ^Exception error)))
       nil)))
 
 (defn- repository-system
@@ -141,7 +141,7 @@
   (let [session (org.apache.maven.repository.internal.MavenRepositorySystemUtils/newSession)
         session (doto session
                   (.setLocalRepositoryManager (.newLocalRepositoryManager
-                                               repository-system
+                                               ^RepositorySystem repository-system
                                                session
                                                (LocalRepository.
                                                 (io/file (or local-repo default-local-repo)))))
@@ -170,7 +170,7 @@
 
 (defn- set-policies
   [repo-builder settings]
-  (doto repo-builder
+  (doto ^RemoteRepository$Builder repo-builder
     (.setSnapshotPolicy (policy settings (:snapshots settings true)))
     (.setReleasePolicy (policy settings (:releases settings true)))))
 
@@ -178,14 +178,14 @@
   [{:keys [username password passphrase private-key-file] :as settings}]
   (-> (AuthenticationBuilder.)
       (.addUsername username)
-      (.addPassword password)
-      (.addPrivateKey private-key-file passphrase)
+      (.addPassword ^String password)
+      (.addPrivateKey ^String private-key-file ^String passphrase)
       .build))
 
 (defn- set-authentication
   [repo-builder {:keys [username password passphrase private-key-file] :as settings}]
   (if (or username password private-key-file passphrase)
-    (.setAuthentication repo-builder (authentication settings))
+    (.setAuthentication ^RemoteRepository$Builder repo-builder (authentication settings))
     repo-builder))
 
 (defn- set-proxy
@@ -196,9 +196,9 @@
     (let [prx-sel (doto (DefaultProxySelector.)
                     (.add (Proxy. type host port (authentication proxy))
                           non-proxy-hosts))
-          prx (.getProxy prx-sel (.build repo-builder))] ; ugg.
+          prx (.getProxy prx-sel (.build ^RemoteRepository$Builder repo-builder))] ; ugg.
       ;; Don't know how to get around "building" the repo for this
-      (.setProxy repo-builder prx))
+      (.setProxy ^RemoteRepository$Builder repo-builder prx))
     repo-builder))
 
 (defn make-repository
@@ -359,7 +359,7 @@
                   :local-repo local-repo
                   :offline? false
                   :transfer-listener transfer-listener})]
-    (.deploy system session
+    (.deploy ^RepositorySystem system session
              (doto (DeployRequest.)
                (.setArtifacts (vec (map (partial create-artifact files) (keys files))))
                (.setRepository (first (map #(make-repository % proxy) repository)))))))
@@ -378,7 +378,7 @@
                   :local-repo local-repo
                   :offline? false
                   :transfer-listener transfer-listener})]
-    (.install system session
+    (.install ^RepositorySystem system session
               (doto (InstallRequest.)
                 (.setArtifacts (vec (map (partial create-artifact files) (keys files))))))))
 
@@ -467,13 +467,13 @@ kwarg to the repository kwarg.
                 (update-in g [(dep-spec dep)]
                            clojure.set/union
                            (->> (.getChildren n)
-                             (map #(.getDependency %))
+                             (map #(.getDependency ^DependencyNode %))
                              (map dep-spec)
                              set))
                 g))
             {}
             (tree-seq (constantly true)
-                      #(seq (.getChildren %))
+                      #(seq (.getChildren ^DependencyNode %))
                       node))))
 
 (defn- mirror-selector-fn
@@ -610,25 +610,25 @@ kwarg to the repository kwarg.
                   :mirror-selector mirror-selector})
         deps (->> coordinates
                   (map #(if-let [local-file (get files %)]
-                          (-> (artifact %)
+                          (-> ^Artifact (artifact %)
                               (.setProperties
                                {ArtifactProperties/LOCAL_PATH
                                 (.getPath (io/file local-file))}))
                           (artifact %)))
                   vec)
         repositories (vec (map #(let [repo (make-repository % proxy)]
-                                  (-> session
+                                  (-> ^RepositorySystemSession session
                                       (.getMirrorSelector)
                                       (.getMirror repo)
                                       (or repo)))
                                repositories))]
     (if retrieve
       (.resolveArtifacts
-       system session (map #(ArtifactRequest. % repositories nil) deps))
+       ^RepositorySystem system session (map #(ArtifactRequest. % repositories nil) deps))
       (doall
        (for [dep deps]
          (.resolveVersion
-          system session (VersionRequest. dep repositories nil)))))))
+          ^RepositorySystem system session (VersionRequest. dep repositories nil)))))))
 
 (defn resolve-artifacts
   "Same as `resolve-artifacts*`, but returns a sequence of dependencies; each
@@ -700,8 +700,8 @@ kwarg to the repository kwarg.
   [files coordinates]
   (->> coordinates
        (map #(if-let [local-file (get files %)]
-              (.setArtifact (dependency %)
-                            (-> (dependency %)
+              (.setArtifact ^Dependency (dependency %)
+                            (-> ^Dependency (dependency %)
                                 .getArtifact
                                 (.setProperties {ArtifactProperties/LOCAL_PATH
                                                  (.getPath (io/file local-file))})))
@@ -797,18 +797,19 @@ kwarg to the repository kwarg.
         coordinates (merge-versions-from-managed-coords coordinates managed-coordinates)
         deps (coords->Dependencies files coordinates)
         managed-deps (coords->Dependencies files managed-coordinates)
-        collect-request (doto (CollectRequest. deps
-                                               managed-deps
+        collect-request (doto (CollectRequest. ^java.util.List deps
+                                               ^java.util.List managed-deps
+                                               ^java.util.List
                                                (vec (map #(let [repo (make-repository % proxy)]
-                                                            (-> session
+                                                            (-> ^RepositorySystemSession session
                                                                 (.getMirrorSelector)
                                                                 (.getMirror repo)
                                                                 (or repo)))
                                                          repositories)))
                           (.setRequestContext "runtime"))]
     (if retrieve
-      (.resolveDependencies system session (DependencyRequest. collect-request nil))
-      (.collectDependencies system session collect-request))))
+      (.resolveDependencies ^RepositorySystem system session (DependencyRequest. collect-request nil))
+      (.collectDependencies ^RepositorySystem system session collect-request))))
 
 (defn resolve-dependencies
   "Same as `resolve-dependencies*`, but returns a graph of dependencies; each
@@ -816,9 +817,14 @@ kwarg to the repository kwarg.
    the dependency's :file on disk.  Please refer to `resolve-dependencies*` for details
    on usage, or use it if you need access to Aether dependency resolution objects."
   [& args]
-  (-> (apply resolve-dependencies* args)
-    .getRoot
-    dependency-graph))
+  (let [result (apply resolve-dependencies* args)]
+    (if (instance? DependencyResult result)
+      (-> ^DependencyResult result
+          .getRoot
+          dependency-graph)
+      (-> ^CollectResult result
+          .getRoot
+          dependency-graph))))
 
 (defn dependency-files
   "Given a dependency graph obtained from `resolve-dependencies`, returns a seq of

--- a/src/test/clojure/cemerick/pomegranate_test.clj
+++ b/src/test/clojure/cemerick/pomegranate_test.clj
@@ -10,10 +10,10 @@
   ; the last classloader should be ext, for e.g. $JAVA_HOME/lib/ext/*
   (is (->> (p/resources [(last (p/classloader-hierarchy))] "META-INF/MANIFEST.MF")
         (map str)
-        (filter #(.contains % "clojure"))
+        (filter #(.contains ^String % "clojure"))
         empty?))
   
   (is (->> (p/resources (butlast (p/classloader-hierarchy)) "META-INF/MANIFEST.MF")
         (map str)
-        (filter #(.contains % "clojure"))
+        (filter #(.contains ^String % "clojure"))
         seq)))


### PR DESCRIPTION
> Closes https://github.com/clj-commons/pomegranate/pull/124

Picks up https://github.com/clj-commons/pomegranate/pull/124 from @emlyn. It's generally a fine commit except for Clojure 1.7 compatibility, and for some further opportunity of addressing the remaining reflection warnings.

That is done in the two following commits.

And the last commit sets up Eastwood as a linter. Starting from 0.9, it lints for reflection warnings in a way that is suitable for CI. You can learn more about how it works / its rationale in https://github.com/jonase/eastwood#reflection