### PR TITLE
Don't accept empty but truthy :repositories

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -34,4 +34,4 @@
 
            :eastwood {:main-opts  ["-m" "eastwood.lint" {:exclude-namespaces [cognitect.test-runner]
                                                          :ignored-faults {:local-shadows-var {cemerick.pomegranate.aether true}}}]
-                      :extra-deps {jonase/eastwood {:mvn/version "0.9.2"}}}}}
+                      :extra-deps {jonase/eastwood {:mvn/version "1.1.1"}}}}}

--- a/src/main/clojure/cemerick/pomegranate/aether.clj
+++ b/src/main/clojure/cemerick/pomegranate/aether.clj
@@ -598,6 +598,9 @@ kwarg to the repository kwarg.
   [& {:keys [repositories coordinates files retrieve local-repo
              transfer-listener offline? proxy mirrors repository-session-fn]
       :or {retrieve true}}]
+  (when repositories
+    (assert (seq repositories)
+            "Empty but truthy `repositories` value found. Please set to nil for using the default, or add a non-empty coll of repositories."))
   (let [repositories (or repositories maven-central)
         system (repository-system)
         mirror-selector-fn (memoize (partial mirror-selector-fn mirrors))


### PR DESCRIPTION
If one passes `[]` as the `:repositories`, fetches would fail.

`[]` can be passed under contrived-enough circumstances, which is what happened to me (making me lose time).