### PR TITLE
Bump deps to address vulnerabilities

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 ## [Pomegranate](http://github.com/cemerick/pomegranate) changelog
 
+### Unreleased
+
+* Bump stale deps, some of which had vulnerabilities ([#134](https://github.com/clj-commons/pomegranate/issues/134)) ([@lread](https://github.com/lread))
+* General quality
+  * Added automated check for vulnerabilities in dependencies ([@lread](https://github.com/lread))
+
 ### [`1.2.1`]
 
 * Upgrade wagon libs from 3.2.2 -> 3.3.4

--- a/deps.edn
+++ b/deps.edn
@@ -1,20 +1,20 @@
 {:paths ["src/main/clojure"]
- :deps {org.apache.maven/maven-resolver-provider {:mvn/version "3.6.1"}
-        org.apache.maven.resolver/maven-resolver-api {:mvn/version "1.3.3"}
-        org.apache.maven.resolver/maven-resolver-spi {:mvn/version "1.3.3"}
-        org.apache.maven.resolver/maven-resolver-util {:mvn/version "1.3.3"}
-        org.apache.maven.resolver/maven-resolver-impl {:mvn/version "1.3.3"}
-        org.apache.maven.resolver/maven-resolver-transport-file {:mvn/version "1.3.3"}
-        org.apache.maven.resolver/maven-resolver-transport-http {:mvn/version "1.3.3"}
-        org.apache.maven.resolver/maven-resolver-transport-wagon {:mvn/version "1.3.3"}
-        org.apache.maven.resolver/maven-resolver-connector-basic {:mvn/version "1.3.3"}
+ :deps {org.apache.maven/maven-resolver-provider {:mvn/version "3.8.7"}
+        org.apache.maven.resolver/maven-resolver-api {:mvn/version "1.9.4"}
+        org.apache.maven.resolver/maven-resolver-spi {:mvn/version "1.9.4"}
+        org.apache.maven.resolver/maven-resolver-util {:mvn/version "1.9.4"}
+        org.apache.maven.resolver/maven-resolver-impl {:mvn/version "1.9.4"}
+        org.apache.maven.resolver/maven-resolver-transport-file {:mvn/version "1.9.4"}
+        org.apache.maven.resolver/maven-resolver-transport-http {:mvn/version "1.9.4"}
+        org.apache.maven.resolver/maven-resolver-transport-wagon {:mvn/version "1.9.4"}
+        org.apache.maven.resolver/maven-resolver-connector-basic {:mvn/version "1.9.4"}
         org.tcrawley/dynapath {:mvn/version "1.0.0"}
-        org.apache.maven.wagon/wagon-provider-api {:mvn/version "3.3.4"
+        org.apache.maven.wagon/wagon-provider-api {:mvn/version "3.5.3"
                                                    :exclusions [org.codehaus.plexus/plexus-utils]}
-        org.apache.maven.wagon/wagon-http {:mvn/version "3.3.4"}
-        org.apache.maven.wagon/wagon-ssh {:mvn/version "3.3.4"}
-        org.apache.httpcomponents/httpclient {:mvn/version "4.5.8"}
-        org.apache.httpcomponents/httpcore {:mvn/version "4.4.11"}}
+        org.apache.maven.wagon/wagon-http {:mvn/version "3.5.3"}
+        org.apache.maven.wagon/wagon-ssh {:mvn/version "3.5.3"}
+        org.apache.httpcomponents/httpclient {:mvn/version "4.5.14"}
+        org.apache.httpcomponents/httpcore {:mvn/version "4.4.16"}}
 
  :aliases {:test {:extra-paths ["src/test/clojure"]
                   :extra-deps {com.cognitect/test-runner {:git/url "https://github.com/cognitect-labs/test-runner.git"

--- a/nvd_check_helper_project/suppressions.xml
+++ b/nvd_check_helper_project/suppressions.xml
@@ -1,4 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <!-- You can find examples in https://jeremylong.github.io/DependencyCheck/general/suppression.html -->
+  <suppress>
+    <notes><![CDATA[
+    This library describes itself as "using netcat" and I think that was enough to trigger these CVEs.
+    It does spawn out to nc, but it does not include AIST netcat.
+    ]]></notes>
+    <filePath regex="true">.*\bjsch.agentproxy.usocket-nc-0.0.9.jar</filePath>
+    <cve>CVE-2008-5730</cve>
+    <cve>CVE-2008-5727</cve>
+    <cve>CVE-2008-5728</cve>
+    <cve>CVE-2015-2214</cve>
+    <cve>CVE-2008-5729</cve>
+    <cve>CVE-2008-5742</cve>
+  </suppress>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -31,14 +31,14 @@
   <parent>
     <groupId>org.clojure</groupId>
     <artifactId>pom.contrib</artifactId>
-    <version>0.2.2</version>
+    <version>1.1.0</version>
   </parent>
 
   <properties>
-    <clojure.version>1.3.0</clojure.version>
-    <mavenVersion>3.6.1</mavenVersion>
-    <resolverVersion>1.3.3</resolverVersion>
-    <wagonVersion>3.3.4</wagonVersion>
+    <clojure.version>1.4.0</clojure.version>
+    <mavenVersion>3.8.7</mavenVersion>
+    <resolverVersion>1.9.4</resolverVersion>
+    <wagonVersion>3.5.3</wagonVersion>
   </properties>
 
   <dependencies>
@@ -119,12 +119,12 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.5.8</version>
+      <version>4.5.14</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpcore</artifactId>
-      <version>4.4.11</version>
+      <version>4.4.16</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Address vulnerabilities reported by nvd-clojure by bumping deps.

Suppress reported CVEs for jsch.agentproxy.usocket-nc. I think they are false positives. See note in nvd suppression config.

Adapt to option change in maven resolver.
Pomegranate, by default, generates checksums for .asc files. This is not the default for maven resolver.
The maven resolver options that control this behaviour changed in maven resolver v1.8. Option aether.checksums.forSignature was replaced with aether.checksums.omitChecksumsForExtensions.
Because I've noticed that pomegranate users have explicitly set the legacy system property in their code, I've decided to have pomegranate automatically upconvert the legacy option to the new option.

Bump min Clojure version from 1.3.0 to 1.4.0.
Pomegranate uses the Clojure core team's parent pom. This means its tests can be run via `mvn test`.
Although `clojure -M:test` was passing, `mvn test` was not. The pom currently configures `mvn test` to use Clojure 1.3.0, bumping this to 1.4.0 has the tests passing.
The `clojure -M:test` uses `deps.edn` which does not specify a version of Clojure, so it defaults to the installed version of Clojure, which on my dev box, at the time of this writing, is 1.11.1.

Out of scope for this change:
- bumping other outdated deps will be handled separately.
- updating duplicated deps in deps.edn and pom.xml is error prone but will be addressed as a separate issue.

Contributes to #134