### PR TITLE
maint: bump dev deps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,10 +17,10 @@ shared: &shared
     - run:
         name: Install Clojure
         command: |
-          wget -nc https://download.clojure.org/install/linux-install-1.10.3.855.sh
-          chmod +x linux-install-1.10.3.855.sh
-          sudo ./linux-install-1.10.3.855.sh
-             
+          wget -nc https://download.clojure.org/install/linux-install-1.11.1.1208.sh
+          chmod +x linux-install-1.11.1.1208.sh
+          sudo ./linux-install-1.11.1.1208.sh
+
     # Download and cache dependencies
     # - restore_cache:
     #    keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ shared: &shared
     # run tests!
     - run: mvn test
     # lint (especially reflection warnings)
-    - run: clojure -A:test:eastwood
+    - run: clojure -M:test:eastwood
 
 jobs:
   java-8:

--- a/deps.edn
+++ b/deps.edn
@@ -17,21 +17,19 @@
         org.apache.httpcomponents/httpcore {:mvn/version "4.4.16"}}
 
  :aliases {:test {:extra-paths ["src/test/clojure"]
-                  :extra-deps {com.cognitect/test-runner {:git/url "https://github.com/cognitect-labs/test-runner.git"
-                                                          :sha "209b64504cb3bd3b99ecfec7937b358a879f55c1"}
-                               org.slf4j/slf4j-simple {:mvn/version "1.7.26"}}
+                  :extra-deps {io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd"}
+                               org.slf4j/slf4j-simple {:mvn/version "2.0.6"}}
                   :main-opts ["-m" "cognitect.test-runner" "-d" "src/test/clojure"]}
            :jar {:extra-deps {seancorfield/depstar {:mvn/version "RELEASE"}}
                  :main-opts ["-m" "hf.depstar.jar" "pomegranate.jar"]}
            :deploy {:extra-deps {slipset/deps-deploy {:git/url "https://github.com/slipset/deps-deploy.git"
-                                                      :sha "b4359c5d67ca002d9ed0c4b41b710d7e5a82e3bf"}}
+                                                      :sha "fd8ff2de9c4bda82a1c69c387d56217473b394be"}}
                     :main-opts ["-m" "deps-deploy.deps-deploy" "deploy"
                                 "pomegranate.jar" "true"]}
            :install {:extra-deps {slipset/deps-deploy {:git/url "https://github.com/slipset/deps-deploy.git"
-                                                       :sha "b4359c5d67ca002d9ed0c4b41b710d7e5a82e3bf"}}
+                                                       :sha "fd8ff2de9c4bda82a1c69c387d56217473b394be"}}
                      :main-opts ["-m" "deps-deploy.deps-deploy" "install"
                                  "pomegranate.jar" "true"]}
-
            :eastwood {:main-opts  ["-m" "eastwood.lint" {:exclude-namespaces [cognitect.test-runner]
                                                          :ignored-faults {:local-shadows-var {cemerick.pomegranate.aether true}}}]
-                      :extra-deps {jonase/eastwood {:mvn/version "1.1.1"}}}}}
+                      :extra-deps {jonase/eastwood {:mvn/version "1.3.0"}}}}}

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
-      <version>1.7.26</version>
+      <version>2.0.6</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
These deps are not included in pomegranate release jar.

Did not bother with the deprecated depstar it shall soon be replaced with tools.build.

Carried on with using HEAD sha of deps-deploy as per its recommended usage in its README.

Contributes to #134