### PR TITLE
ci: beef up test matrix

### DIFF
--- a/.github/workflows/nvd_scanner.yml
+++ b/.github/workflows/nvd_scanner.yml
@@ -15,33 +15,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3.3.0
 
-    - name: Clojure deps cache
-      uses: actions/cache@v3
+    - name: Setup
+      uses: ./github/workflows/shared-setup
       with:
-        path: |
-          ~/.m2/repository
-          ~/.deps.clj
-          ~/.gitlibs
-        key: cljdeps-${{ hashFiles('deps.edn') }}
-        restore-keys: cljdeps-
-
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        distribution: 'temurin'
-        java-version: 17
-
-    - name: Install Clojure Tools
-      uses: DeLaGuardo/setup-clojure@10.1
-      with:
-        cli: 'latest'
-
-    - name: Tools Versions
-      run: |
-        echo "java -version"
-        java -version
-        echo "clojure --version"
-        clojure --version
+        jdk: 11
 
     - name: Get Date
       id: get-date

--- a/.github/workflows/shared-setup/action.yml
+++ b/.github/workflows/shared-setup/action.yml
@@ -1,0 +1,50 @@
+name: 'shared setup'
+inputs:
+  jdk:
+    description: 'jdk version'
+    required: true
+  shell:
+    # shell must be specified for run:s for composite actions
+    description: 'which shell to use'
+    required: false
+    default: bash
+
+runs:
+  using: 'composite'
+
+  steps:
+    - name: Clojure deps cache
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.m2/repository
+          ~/.deps.clj
+          ~/.gitlibs
+        key: cljdeps-${{ hashFiles('deps.edn', 'bb.edn') }}
+        restore-keys: cljdeps-
+
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        java-version: ${{ inputs.jdk }}
+
+    - name: Install Clojure Tools
+      uses: DeLaGuardo/setup-clojure@10.1
+      with:
+        cli: 'latest'
+        bb: 'latest'
+
+    - name: Tools Versions
+      shell: ${{ inputs.shell }}
+      run: |
+        echo "java -version"
+        java -version
+        echo "bb --version"
+        bb --version
+        echo "clojure --version"
+        clojure --version
+
+    - name: Download Clojure Dependencies
+      shell: ${{ inputs.shell }}
+      run: bb download-deps

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,32 @@
+name: tests
+on:
+  # allow this workflow to be called from other workflows, namely: publish
+  workflow_call:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os.name }}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [{name: 'windows', shell: 'pwsh'}, {name: 'ubuntu', shell: 'bash'}]
+        jdk: ['8', '11', '17', '19']
+
+    name: ${{matrix.os.name}} - jdk ${{ matrix.jdk }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Setup
+      uses: ./.github/workflows/shared-setup
+      with:
+        jdk: ${{ matrix.jdk }}
+        shell: ${{ matrix.os.shell }}
+
+    - name: Run tests
+      run: bb test --clj-version :all

--- a/bb.edn
+++ b/bb.edn
@@ -1,0 +1,22 @@
+{:paths ["script"]
+ :deps {lread/status-line {:git/url "https://github.com/lread/status-line.git"
+                           :sha "cf44c15f30ea3867227fa61ceb823e5e942c707f"}}
+ :tasks {;; setup
+         :requires ([babashka.fs :as fs]
+                    [clojure.string :as string]
+                    [lread.status-line :as status])
+         :enter (let [{:keys [name]} (current-task)] (status/line :head "TASK %s %s" name (string/join " " *command-line-args*)))
+         :leave (let [{:keys [name]} (current-task)] (status/line :detail "\nTASK %s done." name))
+
+         ;; tasks
+         clean
+         {:doc "delete build work"
+          :task (when (fs/exists? "target")
+                  (fs/delete-tree "target"))}
+         download-deps
+         {:doc "bring down Clojure deps"
+          :task download-deps/-main}
+         test
+         {:doc "Runs tests under Clojure [--clj-version] (recognizes cognitect test-runner args)"
+          :requires ([test-clj])
+          :task (apply test-clj/-main *command-line-args*)}}}

--- a/doc/02-developer-guide.adoc
+++ b/doc/02-developer-guide.adoc
@@ -1,0 +1,89 @@
+= Developer Guide
+:toclevels: 5
+:toc:
+
+== Audience
+You want contribute to, or learn about, the development of the pomegranate library.
+
+== Contributing
+
+We very much appreciate contributions from the community.
+
+=== Issue First Please
+
+If you have an idea or a fix, please do raise a GitHub issue before investing in any coding effort.
+That way we can discuss first.
+Writing code is the easy part, maintaining it forever is the hard part.
+
+That said, if you notice a simple typo, a PR without an issue is fine.
+
+=== Submitting a Pull Request
+
+Please never force push on your PR, as this makes reviewing incremental changes impossible for us.
+When we merge your PR, we'll usually squash it, so that will clean up any rambling work in progress.
+
+== Environmental Overview
+
+=== Developer Prerequisites
+
+The current version of Babashka.
+The current version of Clojure.
+JDK8+
+
+=== Foundational Library
+
+Leiningen and other tools rely on pomegranate behaving the way it does.
+We must be very careful when making changes.
+
+== Docs
+
+All documentation is written in AsciiDoc. (coming soon)
+@lread likes to follow https://asciidoctor.org/docs/asciidoc-recommended-practices/#one-sentence-per-line[AsciiDoc best practice of one sentence per line] but won't be entirely pedantic about that.
+
+We host our docs on cljdoc. (coming soon)
+
+== The Public API
+
+When making changes to pomegranate understand that any public method is considered part of the public API.
+
+We must be careful not to expose what we feel are implementation details.
+
+== Babashka Tasks
+
+We use Babashka tasks, to see all available tasks run:
+
+[source,shell]
+----
+bb tasks
+----
+
+Optionally:
+
+[source,shell]
+----
+$ bb clean
+$ bb download-deps
+----
+
+Run all Clojure tests
+
+[source,shell]
+----
+$ bb test
+----
+
+You can also include cognitect test runner options:
+
+[source,shell]
+----
+$ bb test --var 'clj-yaml.core-test/emoji-can-be-parsed'
+----
+
+...and/or Clojure version:
+
+[source,shell]
+----
+$ bb test --clj-version 1.9
+----
+(defaults to `1.8`, specify `:all` to test against all supported Clojure versions)
+

--- a/script/download_deps.clj
+++ b/script/download_deps.clj
@@ -1,0 +1,20 @@
+(ns download-deps
+  (:require [babashka.tasks :as t]
+            [clojure.edn :as edn]
+            [lread.status-line :as status]))
+
+;; clojure has a -P command, but to bring down all deps we need to specify all aliases
+;; bb deps will be brought down just from running bb (which assumedly is how this code is run)
+
+(defn -main [& _args]
+  (let [aliases (->> "deps.edn"
+                     slurp
+                     edn/read-string
+                     :aliases
+                     keys)]
+    ;; one at a time because aliases with :replace-deps will... well... you know.
+    (status/line :detail "Bring down default deps")
+    (t/clojure "-P")
+    (doseq [a aliases]
+      (status/line :detail "Bring down deps for alias: %s" a)
+      (t/clojure "-P" (str "-M" a)))))

--- a/script/test_clj.clj
+++ b/script/test_clj.clj
@@ -1,0 +1,46 @@
+(ns test-clj
+  (:require [babashka.cli :as cli]
+            [babashka.tasks :as t]
+            [lread.status-line :as status]))
+
+(defn -main [& args]
+  (let [all-clojure-versions ["1.8" "1.9" "1.10" "1.11"]
+        valid-clj-version-opt-values (conj all-clojure-versions ":all")
+        spec {:clj-version
+              {:ref "<version>"
+               :desc "The Clojure version to test against."
+               :coerce :string
+               :default-desc "1.8"
+               ;; don't specify :default, we want to know if the user passed this option in
+               :validate
+               {:pred (set valid-clj-version-opt-values)
+                :ex-msg (fn [_m]
+                          (str "--clj-version must be one of: " valid-clj-version-opt-values))}}}
+        opts (cli/parse-opts args {:spec spec})
+        clj-version (:clj-version opts)
+        runner-args (if-not clj-version
+                      args
+                      (loop [args args
+                             out-args []]
+                        (if-let [a (first args)]
+                          (if (re-matches #"(--|:)clj-version" a)
+                            (recur (drop 2 args) out-args)
+                            (recur (rest args) (conj out-args a)))
+                          out-args)))
+        clj-version (or clj-version "1.8")]
+
+    (if (:help opts)
+      (do
+        (status/line :head "bb task option help")
+        (println (cli/format-opts {:spec spec}))
+        (status/line :head "test-runner option help")
+        (t/clojure "-M:test --test-help"))
+      (let [clj-versions (if (= ":all" clj-version)
+                           all-clojure-versions
+                           [clj-version])]
+        (doseq [v clj-versions]
+          (status/line :head "Testing against Clojure version %s" v)
+          (apply t/clojure (format "-M:%s:test" v) runner-args))))))
+
+(when (= *file* (System/getProperty "babashka.file"))
+  (apply -main *command-line-args*))

--- a/src/test/clojure/cemerick/pomegranate/aether_test.clj
+++ b/src/test/clojure/cemerick/pomegranate/aether_test.clj
@@ -1,5 +1,6 @@
 (ns cemerick.pomegranate.aether-test
   (:require [cemerick.pomegranate.aether :as aether]
+            [cemerick.pomegranate.test-report]
             [clojure.java.io :as io]
             [clojure.string])
   (:use [clojure.test])

--- a/src/test/clojure/cemerick/pomegranate/test_report.clj
+++ b/src/test/clojure/cemerick/pomegranate/test_report.clj
@@ -1,0 +1,9 @@
+(ns cemerick.pomegranate.test-report
+  (:require [clojure.test]))
+
+(def platform
+  (str "clj " (clojure-version)))
+
+(defmethod clojure.test/report :begin-test-var [m]
+  (let [test-name (-> m :var meta :name)]
+    (println (format "=== %s [%s]" test-name platform))))

--- a/src/test/clojure/cemerick/pomegranate_test.clj
+++ b/src/test/clojure/cemerick/pomegranate_test.clj
@@ -1,5 +1,6 @@
 (ns cemerick.pomegranate-test
   (:require [cemerick.pomegranate :as p]
+            [cemerick.pomegranate.test-report]
             clojure.java.io)
   (:use clojure.test))
 


### PR DESCRIPTION
Add test workflow on GitHub Actions with matrix that runs:
- oses: windows, linux (previously linux only)
- jdks 8, 11, 17, 19 (previously jdks 8 and 13)
- clojure versions: 1.8, 1.9, 1.10, 1.11 (previously 1.4 only)

Now that we have 2 GitHub Actions, now sharing setup.

Add bb tasks to abstract dev cmds.
Add a developer guide doc.
Add a test reporter for more feedback when tests are run.

Will retire current CircleCI test run after I work out any issues with GitHub Actions.

Contributes to #137