### PR TITLE
bump: dynapath

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -8,7 +8,7 @@
         org.apache.maven.resolver/maven-resolver-transport-http {:mvn/version "1.9.4"}
         org.apache.maven.resolver/maven-resolver-transport-wagon {:mvn/version "1.9.4"}
         org.apache.maven.resolver/maven-resolver-connector-basic {:mvn/version "1.9.4"}
-        org.tcrawley/dynapath {:mvn/version "1.0.0"}
+        org.tcrawley/dynapath {:mvn/version "1.1.0"}
         org.apache.maven.wagon/wagon-provider-api {:mvn/version "3.5.3"
                                                    :exclusions [org.codehaus.plexus/plexus-utils]}
         org.apache.maven.wagon/wagon-http {:mvn/version "3.5.3"}

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
     <dependency>
       <groupId>org.tcrawley</groupId>
       <artifactId>dynapath</artifactId>
-      <version>1.0.0</version>
+      <version>1.1.0</version>
     </dependency>
     <!-- wagons for dependency resolution -->
     <dependency>


### PR DESCRIPTION
As of this writing, I think this is the last stale dep of interest.

Does not seem terribly risky as last release was in late 2019 and might help with newer JDKs in some way?

Closes #134