### PR TITLE
dev: add clj-kondo linting

### DIFF
--- a/.clj-kondo/babashka/fs/config.edn
+++ b/.clj-kondo/babashka/fs/config.edn
@@ -1,0 +1,1 @@
+{:lint-as {babashka.fs/with-temp-dir clojure.core/let}}

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,3 @@
+{:config-paths ^:replace [] ;; don't include user configs
+ :linters {:used-underscored-binding {:level :warning}
+           :aliased-namespace-symbol {:level :warning}}}

--- a/.clj-kondo/lread/status-line/config.edn
+++ b/.clj-kondo/lread/status-line/config.edn
@@ -1,0 +1,2 @@
+{:lint-as {lread.status-line/line clojure.tools.logging/infof
+           lread.status-line/die clojure.tools.logging/infof}}

--- a/.clj-kondo/rewrite-clj/rewrite-clj/config.edn
+++ b/.clj-kondo/rewrite-clj/rewrite-clj/config.edn
@@ -1,0 +1,5 @@
+{:lint-as
+ {rewrite-clj.zip/subedit-> clojure.core/->
+  rewrite-clj.zip/subedit->> clojure.core/->>
+  rewrite-clj.zip/edit-> clojure.core/->
+  rewrite-clj.zip/edit->> clojure.core/->>}}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,21 @@ on:
     branches: [ "master" ]
 
 jobs:
+  lint-kondo:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup
+        uses: ./.github/workflows/shared-setup
+        with:
+          jdk: '11'
+
+      - name: Lint
+        run: bb lint-kondo
+
   lint-eastwood:
     runs-on: ubuntu-latest
 

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ tmp
 .cpcache
 .externalToolBuilders
 .eastwood
+# for kondo and lsp caches
+.cache

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,9 @@
   * Address all reflection warnings
   ([@vemv](https://github.com/vemv))
   ([#131](https://github.com/clj-commons/pomegranate/pull/131))
+  * Add automated clj-kondo linting
+  ([@lread](https://github.com/lread))
+  ([#139](https://github.com/clj-commons/pomegranate/pull/139))
 
 ### [`1.2.1`]
 

--- a/bb.edn
+++ b/bb.edn
@@ -20,6 +20,12 @@
          {:doc "Runs tests under Clojure [--clj-version] (recognizes cognitect test-runner args)"
           :requires ([test-clj])
           :task (apply test-clj/-main *command-line-args*)}
+         lint-kondo
+         {:doc "[--rebuild] Lint source code with clj-kondo"
+          :task lint/-main}
          lint-eastwood
          {:doc "Lint source code with Eastwood"
-          :task (clojure "-M:test:eastwood")}}}
+          :task (clojure "-M:test:eastwood")}
+         lint
+         {:doc "Run all lints"
+          :depends [lint-kondo lint-eastwood]} }}

--- a/deps.edn
+++ b/deps.edn
@@ -25,7 +25,7 @@
                   :extra-deps {io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd"}
                                org.slf4j/slf4j-simple {:mvn/version "2.0.6"}}
                   :main-opts ["-m" "cognitect.test-runner" "-d" "src/test/clojure"]}
-           :jar {:extra-deps {seancorfield/depstar {:mvn/version "RELEASE"}}
+           :jar {:extra-deps  {seancorfield/depstar #_:clj-kondo/ignore {:mvn/version "RELEASE"}}
                  :main-opts ["-m" "hf.depstar.jar" "pomegranate.jar"]}
            :deploy {:extra-deps {slipset/deps-deploy {:git/url "https://github.com/slipset/deps-deploy.git"
                                                       :sha "fd8ff2de9c4bda82a1c69c387d56217473b394be"}}
@@ -35,6 +35,10 @@
                                                        :sha "fd8ff2de9c4bda82a1c69c387d56217473b394be"}}
                      :main-opts ["-m" "deps-deploy.deps-deploy" "install"
                                  "pomegranate.jar" "true"]}
+           ;; for consistent linting we use a specific version of clj-kondo through the jvm
+           :clj-kondo {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2023.01.16"}}
+                       :override-deps {org.clojure/clojure {:mvn/version "1.11.1"}}
+                       :main-opts ["-m" "clj-kondo.main"]}
            :eastwood {:main-opts  ["-m" "eastwood.lint" {:exclude-namespaces [cognitect.test-runner]
                                                          :ignored-faults {:local-shadows-var {cemerick.pomegranate.aether true}}}]
                       :extra-deps {jonase/eastwood {:mvn/version "1.3.0"}}}}}

--- a/doc/02-developer-guide.adoc
+++ b/doc/02-developer-guide.adoc
@@ -87,9 +87,12 @@ $ bb test --clj-version 1.9
 ----
 (defaults to `1.8`, specify `:all` to test against all supported Clojure versions)
 
-Our CI workflow lints sources with eastwood - and you can too!
+Our CI workflow lints sources with clj-kondo, and eastwood - and you can too!
 
 [source,shell]
 ----
+$ bb lint-kondo
 $ bb lint-eastwood
 ----
+
+Or to run both: `bb lint`

--- a/script/lint.clj
+++ b/script/lint.clj
@@ -1,0 +1,64 @@
+(ns lint
+  (:require [babashka.classpath :as bbcp]
+            [babashka.cli :as cli]
+            [babashka.fs :as fs]
+            [babashka.tasks :as t]
+            [clojure.string :as string]
+            [lread.status-line :as status]))
+
+(def clj-kondo-cache ".clj-kondo/.cache")
+
+(defn- cache-exists? []
+  (fs/exists? clj-kondo-cache))
+
+(defn- delete-cache []
+  (when (cache-exists?)
+    (fs/delete-tree clj-kondo-cache)))
+
+(defn- build-cache []
+  (when (cache-exists?)
+    (delete-cache))
+  (let [clj-cp (-> (t/clojure {:out :string}
+                              "-Spath -M:test")
+                   with-out-str
+                   string/trim)
+        bb-cp (bbcp/get-classpath)]
+    (status/line :detail "- copying configs")
+    (t/clojure "-M:clj-kondo --skip-lint --copy-configs --lint" clj-cp bb-cp)
+    (status/line :detail "- creating cache")
+    (t/clojure "-M:clj-kondo --dependencies --lint" clj-cp bb-cp)))
+
+(defn- check-cache [{:keys [rebuild]}]
+  (status/line :head "clj-kondo: cache check")
+  (if-let [rebuild-reason (cond
+                            rebuild
+                            "Rebuild requested"
+
+                            (not (cache-exists?))
+                            "Cache not found"
+
+                            :else
+                            (let [updated-dep-files (fs/modified-since clj-kondo-cache ["deps.edn" "bb.edn" "nvd_check_helper_project/deps.edn"])]
+                              (when (seq updated-dep-files)
+                                (format "Found deps files newer than lint cache: %s" (mapv str updated-dep-files)))))]
+    (do (status/line :detail rebuild-reason)
+        (build-cache))
+    (status/line :detail "Using existing cache")))
+
+(defn- lint [opts]
+  (check-cache opts)
+  (status/line :head "clj-kondo: linting")
+  (let [{:keys [exit]}
+        (t/clojure {:continue true}
+                   "-M:clj-kondo --lint src script deps.edn bb.edn nvd_check_helper_project/deps.edn")]
+    (cond
+      (= 2 exit) (status/die exit "clj-kondo found one or more lint errors")
+      (= 3 exit) (status/die exit "clj-kondo found one or more lint warnings")
+      (> exit 0) (status/die exit "clj-kondo returned unexpected exit code"))))
+
+(defn -main [& args]
+  (when-let [opts (cli/parse-opts args)]
+    (lint opts)))
+
+(when (= *file* (System/getProperty "babashka.file"))
+  (apply -main *command-line-args*))

--- a/src/main/clojure/cemerick/pomegranate.clj
+++ b/src/main/clojure/cemerick/pomegranate.clj
@@ -1,26 +1,8 @@
 (ns cemerick.pomegranate
-  (:import (clojure.lang DynamicClassLoader)
-           (java.net URL URLClassLoader))
   (:require [clojure.java.io :as io]
             [cemerick.pomegranate.aether :as aether]
             [dynapath.util :as dp])
   (:refer-clojure :exclude (add-classpath)))
-
-;; call-method pulled from clojure.contrib.reflect, (c) 2010 Stuart Halloway & Contributors
-(defn- call-method
-  "Calls a private or protected method.
-
-  params is a vector of classes which correspond to the arguments to
-  the method e
-
-  obj is nil for static methods, the instance object otherwise.
-
-  The method-name is given a symbol or a keyword (something Named)."
-  [^Class klass method-name params obj & args]
-  (-> klass (.getDeclaredMethod (name method-name)
-                                (into-array Class params))
-    (doto (.setAccessible true))
-    (.invoke obj (into-array Object args))))
 
 (defn classloader-hierarchy
   "Returns a seq of classloaders, with the tip of the hierarchy first.
@@ -45,7 +27,7 @@
    to add that path to the right classloader (with the search rooted at the current
    thread's context classloader)."
   ([jar-or-dir classloader]
-     (if-not (dp/add-classpath-url classloader (.toURL (.toURI (io/file jar-or-dir))))
+     (when-not (dp/add-classpath-url classloader (.toURL (.toURI (io/file jar-or-dir))))
        (throw (IllegalStateException. (str classloader " is not a modifiable classloader")))))
   ([jar-or-dir]
     (let [classloaders (classloader-hierarchy)]

--- a/src/test/clojure/cemerick/pomegranate/aether_test.clj
+++ b/src/test/clojure/cemerick/pomegranate/aether_test.clj
@@ -2,8 +2,8 @@
   (:require [cemerick.pomegranate.aether :as aether]
             [cemerick.pomegranate.test-report]
             [clojure.java.io :as io]
-            [clojure.string])
-  (:use [clojure.test])
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is are testing use-fixtures]])
   (:import (java.io File)))
 
 (deftest dependency-roundtripping
@@ -577,12 +577,12 @@
   <packaging>jar</packaging>
   <version>" version "</version>
   <name>" name "</name>"
-  (if-not (empty? deps)
+  (when-not (empty? deps)
     (apply str
            "<dependencies>"
-           (clojure.string/join "\n"
-                                (for [[n v] deps]
-                                  (str "<dependency>
+           (str/join "\n"
+                     (for [[n v] deps]
+                       (str "<dependency>
                    <groupId>" n "</groupId>
                    <artifactId>"n"</artifactId>
                    <version>"v"</version>
@@ -596,9 +596,9 @@
   <artifactId>" name "</artifactId>
   <versioning>
   <versions>"
-  (clojure.string/join "\n"
-                       (for [v versions]
-                         (str "<version>"v"</version>")))
+  (str/join "\n"
+            (for [v versions]
+              (str "<version>"v"</version>")))
     "</versions>
     <lastUpdated>20120810193549</lastUpdated>
   </versioning>
@@ -625,7 +625,7 @@
         (setTimeout [_ _])
         (setInteractive [_ _])
         (get [_ name file]
-          (let [[n _ version] (clojure.string/split name #"/")]
+          (let [[n _ version] (str/split name #"/")]
             (if (= name (str n "/" n "/maven-metadata.xml"))
               (if-let [versions (get-versions n fake-repo)]
                 (spit file (make-metadata n versions))

--- a/src/test/clojure/cemerick/pomegranate_test.clj
+++ b/src/test/clojure/cemerick/pomegranate_test.clj
@@ -1,12 +1,12 @@
 (ns cemerick.pomegranate-test
   (:require [cemerick.pomegranate :as p]
             [cemerick.pomegranate.test-report]
-            clojure.java.io)
-  (:use clojure.test))
+            [clojure.java.io :as io]
+            [clojure.test :refer [deftest is]]))
 
 (deftest resources
   (is (= (first (p/resources "META-INF/MANIFEST.MF"))
-        (clojure.java.io/resource "META-INF/MANIFEST.MF")))
+        (io/resource "META-INF/MANIFEST.MF")))
   
   ; the last classloader should be ext, for e.g. $JAVA_HOME/lib/ext/*
   (is (->> (p/resources [(last (p/classloader-hierarchy))] "META-INF/MANIFEST.MF")


### PR DESCRIPTION
Some clear clarity wins:
- Removed unused private vars
- Removed unused imported classes

Subjective:
- Unused destructured `:keys` and `:as` now are prefixed with underscore. This allows these items to still act as docs, but conveys that they are not used and more importantly not used on purpose.
- An if without else converted to when. This very clearly conveys intent: no we did not forget the else condition.
- Converted :use clojure.test to :require :refer

Pure subjective liberties (not clj-kondo findings):
- I noticed that some nses were being required and not aliased. To me this indicates the ns is being included for its side effects. An alias, to me, conveys it is being used by code.

Closes #139