### PR TITLE
add some classpath tests, fix a minor bug

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -22,6 +22,7 @@ A release with known breaking changes is marked with:
 * General quality
 ** Review and update docs and docstrings.
 (https://github.com/clj-commons/pomegranate/issues/149[#149])
+(https://github.com/clj-commons/pomegranate/issues/153[#153])
 (https://github.com/lread[@lread])
 ** Update automated testing to cover Linux, Windows, current JDKs, and Clojure v1.4+
 (https://github.com/clj-commons/pomegranate/issues/137[#137])
@@ -40,6 +41,9 @@ A release with known breaking changes is marked with:
 (https://github.com/lread[@lread])
 ** Dependencies now specified only once
 (https://github.com/clj-commons/pomegranate/pull/136[#136])
+(https://github.com/lread[@lread])
+** Review and update classpath related tests
+(https://github.com/clj-commons/pomegranate/pull/154[#154])
 (https://github.com/lread[@lread])
 
 == v1.2.1 - 2021-04-12

--- a/bb.edn
+++ b/bb.edn
@@ -18,7 +18,7 @@
          {:doc "bring down Clojure deps"
           :task download-deps/-main}
          test
-         {:doc "Runs tests under Clojure [--clj-version] (recognizes cognitect test-runner args)"
+         {:doc "Runs tests under Clojure [--clj-version] [--suite] [--help] (recognizes cognitect test-runner args)"
           :requires ([test-clj])
           :task (apply test-clj/-main *command-line-args*)}
          lint-kondo
@@ -26,7 +26,7 @@
           :task lint/-main}
          lint-eastwood
          {:doc "Lint source code with Eastwood"
-          :task (clojure "-M:test:eastwood")}
+          :task (clojure "-M:test:isolated:eastwood")}
          lint
          {:doc "Run all lints"
           :depends [lint-kondo lint-eastwood]}

--- a/deps.edn
+++ b/deps.edn
@@ -38,7 +38,13 @@
                   :extra-deps {io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd"}
                                org.slf4j/slf4j-simple {:mvn/version "2.0.6"}}
                   :main-opts ["-m" "cognitect.test-runner" "-d" "src/test/clojure"]}
-           ;; compatible with Clojure < 1.8, example usage: clojure -M:1.4:test:old-runner
+           ;; some tests affect classloaders and classpaths, we run them separately to not pollute jvm state
+           ;; ex usage: clojure -M:1.10:test:isolated
+           :isolated {:extra-paths ["src/test-isolated/clojure"]
+                      ;; override :test :main-opts
+                      :main-opts ["-m" "cognitect.test-runner" "-d" "src/test-isolated/clojure"]}
+           ;; user older runner for compatibility with Clojure < 1.8,
+           ;; example usage: clojure -M:1.4:test:old-runner
            :old-runner {:override-deps {io.github.cognitect-labs/test-runner
                                         ^:antq/exclude
                                         {:git/sha "209b64504cb3bd3b99ecfec7937b358a879f55c1"}}}

--- a/doc/02-developer-guide.adoc
+++ b/doc/02-developer-guide.adoc
@@ -66,18 +66,29 @@ $ bb download-deps
 ----
 
 === Testing
-Run all Clojure tests
+Run Clojure tests.
+We have 2 suites:
 
+* `:unit` - general unit tests
+* `:isolated` - tests that pollute classloaders and classpath, and are therefore run separately
+
+To run all test suites under Clojure `1.4` (our minimum supported version):
 [source,shell]
 ----
 $ bb test
+----
+
+To only run a single suite:
+[source,shell]
+----
+$ bb test --suite :unit
 ----
 
 You can also include Cognitect test runner options:
 
 [source,shell]
 ----
-$ bb test --var cemerick.pomegranate.aether-test/live-resolution
+$ bb test --suite :unit --var cemerick.pomegranate.aether-test/live-resolution
 ----
 
 ...and/or Clojure version:
@@ -86,7 +97,7 @@ $ bb test --var cemerick.pomegranate.aether-test/live-resolution
 ----
 $ bb test --clj-version 1.9
 ----
-(defaults to `1.4`, specify `:all` to test against all supported Clojure versions)
+(specify `:all` to test against all supported Clojure versions)
 
 === Linting
 Our CI workflow lints sources with clj-kondo, and eastwood - and you can too!

--- a/script/lint.clj
+++ b/script/lint.clj
@@ -19,7 +19,7 @@
   (when (cache-exists?)
     (delete-cache))
   (let [clj-cp (-> (t/clojure {:out :string}
-                              "-Spath -M:test")
+                              "-Spath -M:test:isolated")
                    with-out-str
                    string/trim)
         bb-cp (bbcp/get-classpath)]

--- a/script/test_clj.clj
+++ b/script/test_clj.clj
@@ -1,6 +1,7 @@
 (ns test-clj
   (:require [babashka.cli :as cli]
             [babashka.tasks :as t]
+            [clojure.string :as string]
             [lread.status-line :as status]))
 
 (defn -main [& args]
@@ -8,24 +9,37 @@
         all-clojure-versions (concat old-clojure-versions ["1.8" "1.9" "1.10" "1.11"])
         default-version (first all-clojure-versions)
         valid-clj-version-opt-values (conj all-clojure-versions ":all")
-        spec {:clj-version
+        all-suites [:unit :isolated]
+        valid-suite-opt-values (conj all-suites :all)
+        spec {:suite
+              {:ref "<suite>"
+               :desc (str "The test suite to run, valid values: " (string/join ", " valid-suite-opt-values))
+               :coerce :keyword
+               :default :all
+               :validate
+               {:pred (set valid-suite-opt-values)
+                :ex-msg (fn [_m]
+                          (str "--suite must be one of: " (string/join ", " valid-suite-opt-values)))}}
+              :clj-version
               {:ref "<version>"
-               :desc "The Clojure version to test against."
+               :desc (str "The Clojure version to test against, valid values: " (string/join ", " valid-clj-version-opt-values))
                :coerce :string
+               :booya :foo
                :default-desc default-version
                ;; don't specify :default, we want to know if the user passed this option in
                :validate
                {:pred (set valid-clj-version-opt-values)
                 :ex-msg (fn [_m]
-                          (str "--clj-version must be one of: " valid-clj-version-opt-values))}}}
+                          (str "--clj-version must be one of: " (string/join ", " valid-clj-version-opt-values)))}}}
         opts (cli/parse-opts args {:spec spec})
+        suite (:suite opts)
         clj-version (:clj-version opts)
-        runner-args (if-not clj-version
+        runner-args (if-not (or clj-version suite)
                       args
                       (loop [args args
                              out-args []]
                         (if-let [a (first args)]
-                          (if (re-matches #"(--|:)clj-version" a)
+                          (if (re-matches #"(--|:)(clj-version|suite)" a)
                             (recur (drop 2 args) out-args)
                             (recur (rest args) (conj out-args a)))
                           out-args)))
@@ -36,15 +50,22 @@
         (status/line :head "bb task option help")
         (println (cli/format-opts {:spec spec}))
         (status/line :head "test-runner option help")
-        (t/clojure "-M:test --test-help"))
-      (let [clj-versions (if (= ":all" clj-version)
+        (t/clojure "-M:test:old-runner --test-help"))
+      (let [suites (if (= :all suite)
+                     all-suites
+                     [suite])
+            clj-versions (if (= ":all" clj-version)
                            all-clojure-versions
                            [clj-version])]
         (doseq [v clj-versions
+                s suites
                 :let [test-alias (if (some #{v} old-clojure-versions)
                                    "test:old-runner"
-                                   "test")]]
-          (status/line :head "Testing against Clojure version %s" v)
+                                   "test")
+                      test-alias (if (= :isolated s)
+                                   (str test-alias ":isolated")
+                                   test-alias)]]
+          (status/line :head "Testing %s suite against Clojure version %s" s v)
           (apply t/clojure (format "-M:%s:%s" v test-alias) runner-args))))))
 
 (when (= *file* (System/getProperty "babashka.file"))

--- a/src/test-isolated/clojure/cemerick/pomegranate_isolated_test.clj
+++ b/src/test-isolated/clojure/cemerick/pomegranate_isolated_test.clj
@@ -1,0 +1,42 @@
+(ns cemerick.pomegranate-isolated-test
+  "These tests modify the classpath and are to be run in their own isolated process.
+  They are not REPL friendly and will fail if run multiple times."
+  (:require [cemerick.pomegranate :as p]
+            [cemerick.pomegranate.aether :as aether]
+            [cemerick.pomegranate.test-report]
+            [clojure.test :refer [deftest is]]))
+
+;; Simulate dynamic classloader available by default in a REPL session
+(defn bind-dynamic-loader
+  "Ensures the clojure.lang.Compiler/LOADER var is bound to a DynamicClassLoader,
+  so that we can add to Clojure's classpath dynamically."
+  []
+  (when-not (bound? Compiler/LOADER)
+    (.bindRoot Compiler/LOADER (clojure.lang.DynamicClassLoader. (clojure.lang.RT/baseLoader)))))
+
+(defn simulated-repl-loader [] (deref clojure.lang.Compiler/LOADER))
+
+(deftest add-dependency-to-classpath
+  (is (thrown-with-msg? java.io.FileNotFoundException #"Could not locate"
+                        (require '[clojure.math.numeric-tower :as math])))
+  (bind-dynamic-loader)
+  ;; numeric tower is hosted on maven so default repositories is fine
+  (p/add-dependencies :classloader (simulated-repl-loader)
+                      :coordinates [['org.clojure/math.numeric-tower "0.0.5"]])
+  (require '[clojure.math.numeric-tower :as math])
+  ;; need a resolve because require is not top-level (requiring-resolve is Clojure 1.10+ so we avoid it)
+  (is (= 4 ((resolve 'math/expt) 2 2))))
+
+(deftest add-dependencies-to-classpath
+  (is (thrown-with-msg? java.io.FileNotFoundException #"Could not locate"
+                        ;; not crazy about single segment ns as an example but matches README
+                        (require '[incanter.core :as i])))
+  (bind-dynamic-loader)
+  ;; incanter is hosted on clojars
+  ;; pick an ancient version for compatibility with Pomegranate supported min clojure version
+  (p/add-dependencies :classloader (simulated-repl-loader)
+                      :coordinates [['incanter/incanter "1.4.1"]]
+                      :repositories (assoc aether/maven-central "clojars" "https://repo.clojars.org"))
+  (require '[incanter.core :as i])
+  ;; need a resolve because require is not top-level (requiring-resolve is Clojure 1.10+ so we avoid it)
+  (is (= 3 ((resolve 'i/length) [1 2 3]))))

--- a/src/test/clojure/cemerick/pomegranate/test_report.clj
+++ b/src/test/clojure/cemerick/pomegranate/test_report.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test]))
 
 (def platform
-  (str "clj " (clojure-version)))
+  (str "clj " (clojure-version) " jdk " (System/getProperty "java.version")))
 
 (defmethod clojure.test/report :begin-test-var [m]
   (let [test-name (-> m :var meta :name)]

--- a/src/test/clojure/cemerick/pomegranate_test.clj
+++ b/src/test/clojure/cemerick/pomegranate_test.clj
@@ -2,19 +2,43 @@
   (:require [cemerick.pomegranate :as p]
             [cemerick.pomegranate.test-report]
             [clojure.java.io :as io]
+            [clojure.string :as string]
             [clojure.test :refer [deftest is]]))
 
+(def java-version-major (-> (System/getProperty "java.version") (string/split #"\.") first Integer/parseInt))
+
 (deftest resources
-  (is (= (first (p/resources "META-INF/MANIFEST.MF"))
-        (io/resource "META-INF/MANIFEST.MF")))
+  (let [r (first (p/resources "META-INF/MANIFEST.MF"))]
+    (is (not (nil? r))
+        "first pomegranate resource match is not nil")
+
+    (is (= r
+           (io/resource "META-INF/MANIFEST.MF"))
+        "first pomegranate resources match is the same as java resource match"))
   
-  ; the last classloader should be ext, for e.g. $JAVA_HOME/lib/ext/*
-  (is (->> (p/resources [(last (p/classloader-hierarchy))] "META-INF/MANIFEST.MF")
-        (map str)
-        (filter #(.contains ^String % "clojure"))
-        empty?))
+  (let [^ClassLoader platform-classloader (last (p/classloader-hierarchy))
+        class-name (-> platform-classloader .getClass .getSimpleName) ]
+    (if (< java-version-major 9)
+      (is (= "ExtClassLoader" class-name)
+          "last class loader is extension classloader (for jdk versions < 9)")
+      (is (= "PlatformClassLoader" class-name)
+          "last class loader is platform classloader (for jdk versions >= 9)"))
+
+    (is (->> (p/resources [platform-classloader] "META-INF/MANIFEST.MF")
+             (map str)
+             (filter #(.contains ^String % "clojure"))
+             empty?)
+        "no clojure manifest resources should be found on platform classloader"))
   
   (is (->> (p/resources (butlast (p/classloader-hierarchy)) "META-INF/MANIFEST.MF")
-        (map str)
-        (filter #(.contains ^String % "clojure"))
-        seq)))
+           (map str)
+           (filter #(.contains ^String % "clojure"))
+           seq)
+      "clojure manifests should be found when searching classloaders"))
+
+(deftest get-classpath
+  (if (< java-version-major 9)
+    (is (seq (p/get-classpath))
+        "works for jdk versions < 9")
+    (is (empty? (p/get-classpath))
+        "always empty seq for jdk versions >= 9")))


### PR DESCRIPTION
Reviewed/updated pomegranate ns tests.

Added some sanity testing for adding to the classpath. Since these modify classpaths they are run separately under a new `:isolated` test suite.

Added a warning to `get-classpath` docstring about JDK9+ behaviour.

Minor test fix: help for the cognitect runner is now invoked with old runner so it does not barf on old versions of Clojure.

Test reporter now also includes JDK version in addition to Clojure version. This might seem excessive, but because these are important for Pomegranate, I like a super-in-my-face reminder of what environment I am testing against.

Minor fix to Pomegranate exception messages now show simple classloader class name, for example:
- previously: `java.lang.IllegalStateException: Could not find a suitable classloader to modify from clojure.lang.LazySeq@15c5d461`
- now: `java.lang.IllegalStateException: Could not find a suitable classloader to modify from ["AppClassLoader" "ExtClassLoader"]`

Closes #153, closes #154