### PR TITLE
Do not set default scope in managed dependencies

### DIFF
--- a/src/test/clojure/cemerick/pomegranate/aether_test.clj
+++ b/src/test/clojure/cemerick/pomegranate/aether_test.clj
@@ -250,6 +250,15 @@
                               files))))
       (is (= 1 (count (filter #(file-path-eq % (io/file tmp-dir "local-repo" "demo" "demo" "1.0.1" "demo-1.0.1.jar"))
                               files))))))
+  (testing "scope is honored for transitive deps when using managed dependencies"
+    (let [deps (aether/resolve-dependencies
+                 :repositories test-repo
+                 :coordinates '[[demo/demo2 "1.0.0" :scope "test"]]
+                 :managed-coordinates '[[demo/demo "1.0.1"]]
+                 :local-repo tmp-local-repo-dir)]
+      (is (= '{[demo/demo2 "1.0.0" :scope "test"] #{[demo "1.0.1" :scope "test"]}
+               [demo "1.0.1" :scope "test"] nil}
+             deps))))
   (testing "unused entries in managed coordinates are not resolved"
     (let [deps (aether/resolve-dependencies
                 :repositories test-repo


### PR DESCRIPTION
If we explicitly add a scope to the Dependency object of a managed dependency (as we were doing, forcing `compile` if not provided), the resolved transitive dependency will use the explicit scope from the managed dependency (i.e. always resolving to `compile`).

Fixes https://github.com/clj-commons/pomegranate/issues/125, by not forcing a default scope for managed dependencies. This way, the resolved version will be from the managed dependency, but the scope of the original dependency will be preserved.