### PR TITLE
test & ci: bump deps, tweak pubcheck

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -1,7 +1,7 @@
 {:paths ["script" "build"]
  :deps {lread/status-line {:git/url "https://github.com/lread/status-line.git"
                            :sha "cf44c15f30ea3867227fa61ceb823e5e942c707f"}
-        io.github.babashka/neil {:git/tag "v0.3.65" :git/sha "9a79582"}}
+        io.github.babashka/neil {:git/tag "v0.3.67" :git/sha "054ca51"}}
  :tasks {;; setup
          :requires ([babashka.fs :as fs]
                     [clojure.string :as string]

--- a/deps.edn
+++ b/deps.edn
@@ -35,7 +35,7 @@
            :1.9 {:override-deps {org.clojure/clojure {:mvn/version "1.9.0"}}}
            :1.10 {:override-deps {org.clojure/clojure {:mvn/version "1.10.3"}}}
            :1.11 {:override-deps {org.clojure/clojure {:mvn/version "1.11.3"}}}
-           :1.12 {:override-deps {org.clojure/clojure {:mvn/version "1.12.0-beta1"}}}
+           :1.12 {:override-deps {org.clojure/clojure {:mvn/version "1.12.0-beta2"}}}
 
            :test {:extra-paths ["src/test/clojure"]
                   :extra-deps {io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd"}
@@ -53,7 +53,7 @@
                                         {:git/sha "209b64504cb3bd3b99ecfec7937b358a879f55c1"}}}
 
            :build {:extra-paths ["build"]
-                   :deps {io.github.clojure/tools.build {:mvn/version "0.10.4"}
+                   :deps {io.github.clojure/tools.build {:mvn/version "0.10.5"}
                           slipset/deps-deploy {:mvn/version "0.2.2"}}
                    :ns-default build}
 
@@ -64,9 +64,9 @@
            :eastwood {:main-opts  ["-m" "eastwood.lint" {:exclude-namespaces [cognitect.test-runner]
                                                          :ignored-faults {:local-shadows-var {cemerick.pomegranate.aether true}}}]
                       :override-deps {org.clojure/clojure {:mvn/version "1.11.3"}}
-                      :extra-deps {jonase/eastwood {:mvn/version "1.4.2"}}}
+                      :extra-deps {jonase/eastwood {:mvn/version "1.4.3"}}}
 
-           :outdated {:extra-deps {com.github.liquidz/antq {:mvn/version "2.8.1201"}
+           :outdated {:extra-deps {com.github.liquidz/antq {:mvn/version "2.8.1206"}
                                    org.clojure/clojure {:mvn/version "1.11.3"}
                                    org.slf4j/slf4j-simple {:mvn/version "2.0.13"} ;; to rid ourselves of logger warnings
                                    }

--- a/script/publish.clj
+++ b/script/publish.clj
@@ -60,12 +60,15 @@
       string/trim
       seq))
 
+(defn- local-branch? []
+  (let [{:keys [exit]} (t/shell {:continue true :out :string :err :out}
+                                "git rev-parse --symbolic-full-name @{u}")]
+    (not (zero? exit))))
+
 (defn- unpushed-commits? []
   (let [{:keys [exit :out]} (t/shell {:continue true :out :string}
                                      "git cherry -v")]
-    (if (zero? exit)
-      (-> out string/trim seq)
-      (status/die 1 "Failed to check for unpushed commits, are you on an unpushed branch?"))))
+    (and (zero? exit) (-> out string/trim seq))))
 
 (defn- commit-matches-master? []
   (let [master-head-sha (-> (t/shell {:out :string} (format "git ls-remote https://github.com/%s.git master" (build-shared/lib-github-coords)))
@@ -106,7 +109,7 @@
      {:check "no uncommitted code"
       :result (if (uncommitted-code?) :fail :pass)}
      {:check "no unpushed commits"
-      :result (if (unpushed-commits?) :fail :pass)}
+      :result (if (or (local-branch?) (unpushed-commits?)) :fail :pass)}
      {:check "in synch with master HEAD"
       :result (if (commit-matches-master?) :pass :fail)}
      {:check "changelog has unreleased section"


### PR DESCRIPTION
Of note:
- clojure 1.12 beta2!
- bb `pubcheck` task can now run checks on unpushed branch