### PR TITLE
Use HttpTransport instead HttpWagon by default

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,7 +13,11 @@ A release with known breaking changes is marked with:
 //   (adjust these in publish.clj as you see fit)
 == Unreleased
 
-
+* Support reporting of problem details as per RFC 9457.
+This means we now use HttpTransport instead of HttpWagon by default,
+and includes upgrading the dependency on `org.apache.maven.resolver/maven-resolver-transport-file` and related libraries
+(https://github.com/clj-commons/pomegranate/pull/233[#233])
+(https://github.com/tobias[@tobias])
 * Override maven dep of `org.codehaus.plexus/plexus-utils` to address CVE-2025-67030
 (https://github.com/clj-commons/pomegranate/issues/234[#234])
 (https://github.com/lread[@lread])

--- a/bb.edn
+++ b/bb.edn
@@ -44,7 +44,8 @@
                       explanations {'commons-logging/commons-logging  "ikcy but: legacy dep still included to avoid breaking existing apps that depend on it transitively"
                                     'org.apache.commons/commons-lang3 "brought in by org.apache.maven.resolver/maven-resolver-impl, override to address CVE-2025-48924"
                                     'org.codehaus.plexus/plexus-utils "brought in by various maven deps, override to address CVE-2025-67030"
-                                    'org.codehaus.plexus/plexus-xml   "optional dep of plexus-utils must be explicitly included"}
+                                    'org.codehaus.plexus/plexus-xml   "optional dep of plexus-utils must be explicitly included"
+                                    'org.apache.maven.wagon/wagon-ssh "this wagon is not explicitly referenced by code, but removing it would be a breaking change for existing apps that depend on it transitively"}}
                       unused-deps (->> (exec 'borkdude.unused-deps/unused-deps
                                         {:source-paths ["src/main/clojure"]})
                                        :unused-deps

--- a/bb.edn
+++ b/bb.edn
@@ -42,13 +42,9 @@
           :requires ([clj-commons.format.table :as table])
           :task (let [;; manually update explanations as needed
                       explanations {'commons-logging/commons-logging  "ikcy but: legacy dep still included to avoid breaking existing apps that depend on it transitively"
-                                    'org.apache.maven.resolver/maven-resolver-transport-http "UNSURE: Might be runtime dep in some scenarios?"
                                     'org.apache.commons/commons-lang3 "brought in by org.apache.maven.resolver/maven-resolver-impl, override to address CVE-2025-48924"
                                     'org.codehaus.plexus/plexus-utils "brought in by various maven deps, override to address CVE-2025-67030"
-                                    'org.codehaus.plexus/plexus-xml   "optional dep of plexus-utils must be explicitly included"
-                                    'org.apache.maven.wagon/wagon-provider-api "wagons are not explicitly referenced by code"
-                                    'org.apache.maven.wagon/wagon-http         "wagons are not explicitly referenced by code"
-                                    'org.apache.maven.wagon/wagon-ssh          "wagons are not explicitly referenced by code"}
+                                    'org.codehaus.plexus/plexus-xml   "optional dep of plexus-utils must be explicitly included"}
                       unused-deps (->> (exec 'borkdude.unused-deps/unused-deps
                                         {:source-paths ["src/main/clojure"]})
                                        :unused-deps

--- a/bb.edn
+++ b/bb.edn
@@ -45,7 +45,7 @@
                                     'org.apache.commons/commons-lang3 "brought in by org.apache.maven.resolver/maven-resolver-impl, override to address CVE-2025-48924"
                                     'org.codehaus.plexus/plexus-utils "brought in by various maven deps, override to address CVE-2025-67030"
                                     'org.codehaus.plexus/plexus-xml   "optional dep of plexus-utils must be explicitly included"
-                                    'org.apache.maven.wagon/wagon-ssh "this wagon is not explicitly referenced by code, but removing it would be a breaking change for existing apps that depend on it transitively"}}
+                                    'org.apache.maven.wagon/wagon-ssh "this wagon is not explicitly referenced by code, but removing it would be a breaking change for existing apps that depend on it transitively"}
                       unused-deps (->> (exec 'borkdude.unused-deps/unused-deps
                                         {:source-paths ["src/main/clojure"]})
                                        :unused-deps

--- a/deps.edn
+++ b/deps.edn
@@ -18,7 +18,8 @@
         org.apache.maven.resolver/maven-resolver-connector-basic {:mvn/version "1.9.25"}
 
         org.apache.maven.wagon/wagon-http {:mvn/version "3.5.3"}
-
+        org.apache.maven.wagon/wagon-ssh {:mvn/version "3.5.3"}
+        
         ;; override commons-lang3 dep brought in by org.apache.maven.resolver/maven-resolver-impl
         ;; to address CVE-2025-48924
         org.apache.commons/commons-lang3 {:mvn/version "3.18.0"}

--- a/deps.edn
+++ b/deps.edn
@@ -18,7 +18,6 @@
         org.apache.maven.resolver/maven-resolver-connector-basic {:mvn/version "1.9.25"}
 
         org.apache.maven.wagon/wagon-http {:mvn/version "3.5.3"}
-        org.apache.maven.wagon/wagon-ssh {:mvn/version "3.5.3"}
 
         ;; override commons-lang3 dep brought in by org.apache.maven.resolver/maven-resolver-impl
         ;; to address CVE-2025-48924

--- a/deps.edn
+++ b/deps.edn
@@ -79,7 +79,8 @@
                        :override-deps {org.clojure/clojure {:mvn/version "1.12.2"}}
                        :main-opts ["-m" "clj-kondo.main"]}
            :eastwood {:main-opts  ["-m" "eastwood.lint" {:exclude-namespaces [cognitect.test-runner]
-                                                         :ignored-faults {:local-shadows-var {cemerick.pomegranate.aether true}}}]
+                                                         :ignored-faults {:deprecations {cemerick.pomegranate.aether {:line 128}}
+                                                                          :local-shadows-var {cemerick.pomegranate.aether true}}}]
                       :override-deps {org.clojure/clojure {:mvn/version "1.12.2"}}
                       :extra-deps {jonase/eastwood {:mvn/version "1.4.3"}}}
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,17 +1,22 @@
 {:paths ["src/main/clojure"]
  :deps {;; our current minimum supported Clojure version
         org.clojure/clojure {:mvn/version "1.4.0"}
+
         ;; TIP: be sure you really want to bump org.apache.maven deps
+        ;; Note that using 3.9.x of maven-resolver-provider will break dependency resolution
+        ;; for transitive deps of transitive deps for an unknown reason. 
         org.apache.maven/maven-resolver-provider {:mvn/version "3.8.7"}
-        org.apache.maven.resolver/maven-resolver-api {:mvn/version "1.9.4"}
-        org.apache.maven.resolver/maven-resolver-spi {:mvn/version "1.9.4"}
-        org.apache.maven.resolver/maven-resolver-util {:mvn/version "1.9.4"}
-        org.apache.maven.resolver/maven-resolver-impl {:mvn/version "1.9.4"}
-        org.apache.maven.resolver/maven-resolver-transport-file {:mvn/version "1.9.4"}
-        org.apache.maven.resolver/maven-resolver-transport-http {:mvn/version "1.9.4"}
-        org.apache.maven.resolver/maven-resolver-transport-wagon {:mvn/version "1.9.4"}
-        org.apache.maven.resolver/maven-resolver-connector-basic {:mvn/version "1.9.4"}
-        org.apache.maven.wagon/wagon-provider-api {:mvn/version "3.5.3"}
+        org.apache.maven.resolver/maven-resolver-impl {:mvn/version "1.9.25"}
+        org.apache.maven.resolver/maven-resolver-transport-file {:mvn/version "1.9.25"}
+        
+        org.apache.maven.resolver/maven-resolver-transport-http
+        {:mvn/version "1.9.25"
+         ;; Brought in via com.google.code.gson/gson, but not needed at runtime
+         :exclusions [com.google.errorprone/error_prone_annotations]}
+        
+        org.apache.maven.resolver/maven-resolver-transport-wagon {:mvn/version "1.9.25"}
+        org.apache.maven.resolver/maven-resolver-connector-basic {:mvn/version "1.9.25"}
+
         org.apache.maven.wagon/wagon-http {:mvn/version "3.5.3"}
         org.apache.maven.wagon/wagon-ssh {:mvn/version "3.5.3"}
 
@@ -32,7 +37,7 @@
         ;; modern apps using pomegranate should exclude it and instead use a bridge like `jcl-over-slf4j`
         commons-logging/commons-logging {:mvn/version "1.3.6"}}
 
- :aliases {;; we use babashka/neil for project attributes
+ :aliases { ;; we use babashka/neil for project attributes
            ;; publish workflow references these values (and automatically bumps patch component of version)
            :neil {:project {:version "1.2.25"
                             ;; artifact deploy name (and also, by chance, GitHub coordinates)

--- a/deps.edn
+++ b/deps.edn
@@ -78,8 +78,7 @@
                        :override-deps {org.clojure/clojure {:mvn/version "1.12.2"}}
                        :main-opts ["-m" "clj-kondo.main"]}
            :eastwood {:main-opts  ["-m" "eastwood.lint" {:exclude-namespaces [cognitect.test-runner]
-                                                         :ignored-faults {:deprecations {cemerick.pomegranate.aether {:line 128}}
-                                                                          :local-shadows-var {cemerick.pomegranate.aether true}}}]
+                                                         :ignored-faults {:local-shadows-var {cemerick.pomegranate.aether true}}}]
                       :override-deps {org.clojure/clojure {:mvn/version "1.12.2"}}
                       :extra-deps {jonase/eastwood {:mvn/version "1.4.3"}}}
 

--- a/src/main/clojure/cemerick/pomegranate/aether.clj
+++ b/src/main/clojure/cemerick/pomegranate/aether.clj
@@ -115,6 +115,16 @@
                         (serviceCreationFailed [type-clazz impl-clazz ^Throwable e]
                           (stacktrace/print-cause-trace e)))]
     (.getService
+     ;; DefaultServiceLocator is deprecated. The javadocs for it state:
+     ;;
+     ;; > Use of out-of-the-box DI implementation recommended, or, as
+     ;; > alternative new supplier from module maven-resolver-supplier.
+     ;;
+     ;; The approach it is referring to is to extend
+     ;; https://github.com/apache/maven-resolver/blob/maven-resolver-1.9.27/maven-resolver-supplier/src/main/java/org/eclipse/aether/supplier/RepositorySystemSupplier.java
+     ;; with a subclass that overrides the appropriate methods. However, it uses
+     ;; a very different API from the ServiceLocator, so would be a significant
+     ;; change to support.
      (doto (MavenRepositorySystemUtils/newServiceLocator)
        (.setService TransporterFactory HttpTransporterFactory)
        (.setService WagonProvider PomegranateWagonProvider)
@@ -894,8 +904,8 @@
                (re-find (re-pattern (str "^" ver "-\\d+\\.\\d+-\\d+$"))
                         version)
                (let [gsv (GenericVersionScheme.)
-                     vc (.parseVersionConstraint gsv sversion)
-                     v (.parseVersion gsv version)]
+                     vc (.parseVersionConstraint gsv ^String sversion)
+                     v (.parseVersion gsv ^String version)]
                  (.containsVersion vc v)))))))
 
 (defn dependency-hierarchy

--- a/src/main/clojure/cemerick/pomegranate/aether.clj
+++ b/src/main/clojure/cemerick/pomegranate/aether.clj
@@ -6,6 +6,7 @@
             [clojure.string :as str]
             [clojure.stacktrace :as stacktrace])
   (:import (org.eclipse.aether RepositorySystem RepositorySystemSession DefaultRepositorySystemSession)
+           (org.eclipse.aether.transport.http HttpTransporterFactory)
            (org.eclipse.aether.transport.wagon WagonTransporterFactory
                                                WagonProvider)
            (org.eclipse.aether.transport.file FileTransporterFactory)
@@ -115,9 +116,10 @@
                           (stacktrace/print-cause-trace e)))]
     (.getService
      (doto (MavenRepositorySystemUtils/newServiceLocator)
-       (.setService TransporterFactory WagonTransporterFactory)
+       (.setService TransporterFactory HttpTransporterFactory)
        (.setService WagonProvider PomegranateWagonProvider)
        (.addService RepositoryConnectorFactory BasicRepositoryConnectorFactory)
+       (.addService TransporterFactory WagonTransporterFactory)
        (.addService TransporterFactory FileTransporterFactory)
        (.setErrorHandler error-handler))
      RepositorySystem)))

--- a/src/main/clojure/cemerick/pomegranate/aether.clj
+++ b/src/main/clojure/cemerick/pomegranate/aether.clj
@@ -28,7 +28,8 @@
            (org.eclipse.aether.util.version GenericVersionScheme)
            (org.eclipse.aether.connector.basic BasicRepositoryConnectorFactory)
            (org.eclipse.aether.impl DefaultServiceLocator$ErrorHandler)
-           (org.apache.maven.repository.internal MavenRepositorySystemUtils)))
+           (org.apache.maven.repository.internal MavenRepositorySystemUtils)
+           (org.apache.maven.wagon.providers.http HttpWagon)))
 
 (def ^{:private true} default-local-repo
   (io/file (System/getProperty "user.home") ".m2" "repository"))
@@ -40,7 +41,7 @@
 (def ^{:private true} wagon-factories
   ;; there were issues with the HTTP lightweight Wagon (now deprecated by Maven),
   ;; so we match the Maven tool itself and use HttpWagon.
-  (atom {"https" #(org.apache.maven.wagon.providers.http.HttpWagon.)
+  (atom {"https" #(HttpWagon.)
          "http" #(throw (Exception. "Tried to use insecure HTTP repository."))}))
 
 (defn register-wagon-factory!

--- a/src/main/clojure/cemerick/pomegranate/aether.clj
+++ b/src/main/clojure/cemerick/pomegranate/aether.clj
@@ -116,16 +116,6 @@
                         (serviceCreationFailed [type-clazz impl-clazz ^Throwable e]
                           (stacktrace/print-cause-trace e)))]
     (.getService
-     ;; DefaultServiceLocator is deprecated. The javadocs for it state:
-     ;;
-     ;; > Use of out-of-the-box DI implementation recommended, or, as
-     ;; > alternative new supplier from module maven-resolver-supplier.
-     ;;
-     ;; The approach it is referring to is to extend
-     ;; https://github.com/apache/maven-resolver/blob/maven-resolver-1.9.27/maven-resolver-supplier/src/main/java/org/eclipse/aether/supplier/RepositorySystemSupplier.java
-     ;; with a subclass that overrides the appropriate methods. However, it uses
-     ;; a very different API from the ServiceLocator, so would be a significant
-     ;; change to support.
      (doto (MavenRepositorySystemUtils/newServiceLocator)
        (.setService TransporterFactory HttpTransporterFactory)
        (.setService WagonProvider PomegranateWagonProvider)


### PR DESCRIPTION
This switches to using HttpTransport over HttpWagon by default, as Transports are preferred over Wagons now[1]. This also updates the maven resolver deps to be the latest.

The motivation for this change is to support RFC 9457 - Problem Details for HTTP APIs[2] responses, and support for them was added in maven-resolver 1.9.24, but only to the HttpTransport.

The HttpWagon only supports displaying a custom message to the user on deploy failure if the message is returned via the status message, usage of which is deprecated in HTTP/1.1. Clojars currently has a fork[3] of http-kit in order to set this status message, but also returns RFC 9457 responses.

[1]: https://maven.apache.org/guides/mini/guide-resolver-transport.html
[2]: https://www.rfc-editor.org/rfc/rfc9457.html
[3]: https://github.com/clojars/http-kit

I've tested this with Clojars locally, and this is enough for problem details to be properly propagated to the caller.

I'm happy to discuss this change, and see if other things need to change as well or if we want more tests. One thing to discuss: do we want to add a way to register custom transports, like we do with wagons? The custom wagon registration still works, but do we want to move towards more general transport support?

## TODO
- [x] Ensure lein tests pass
- [x] Ensure lein reports RFC 9457 failures