### PR TITLE
Prevent deploy output from being interleaved

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,6 +13,11 @@ A release with known breaking changes is marked with:
 //   (adjust these in publish.clj as you see fit)
 == Unreleased
 
+* Serialize deploy output to prevent messages from being improperly interleaved.
+This is required now as the newer HttpTransporter uploads artifacts in parallel.
+(https://github.com/clj-commons/pomegranate/pull/243[#243])
+(https://github.com/tobias[@tobias])
+
 == v1.3.26 - 2026-04-08 [[v1.3.26]]
 
 * Support reporting of problem details as per RFC 9457.

--- a/src/main/clojure/cemerick/pomegranate/aether.clj
+++ b/src/main/clojure/cemerick/pomegranate/aether.clj
@@ -94,21 +94,26 @@
                 :transfer-start-time (.getTransferStartTime r)
                 :trace (.getTrace r)})})
 
+(def ^:private stdout-print-lock (Object.))
+
 (defn- stdout-listener-fn
   [{:keys [type method _transferred resource error] :as _evt}]
   (let [{:keys [name size repository _transfer-start-time]} resource]
-    (case type
-      :started (do
-                 (print (case method :get "Retrieving" :put "Sending")
-                        name
-                        (if (neg? size)
-                          ""
-                          (format "(%sk)" (Math/round (double (max 1 (/ size 1024)))))))
-                 (when (< 70 (+ 10 (count name) (count repository)))
-                   (println) (print "    "))
-                 (println (case method :get "from" :put "to") repository))
-      (:corrupted :failed) (when error (println (.getMessage ^Exception error)))
-      nil)))
+    ;; Prevent interleaved output from multiple deploy threads from overwriting
+    ;; each other
+    (locking stdout-print-lock
+      (case type
+        :started (do
+                   (print (case method :get "Retrieving" :put "Sending")
+                          name
+                          (if (neg? size)
+                            ""
+                            (format "(%sk)" (Math/round (double (max 1 (/ size 1024)))))))
+                   (when (< 70 (+ 10 (count name) (count repository)))
+                     (println) (print "    "))
+                   (println (case method :get "from" :put "to") repository))
+        (:corrupted :failed) (when error (println (.getMessage ^Exception error)))
+        nil))))
 
 (defn- repository-system
   []


### PR DESCRIPTION
HttpTransporter uploads artifacts in parallel, resulting in output that gets interleaved with output from other threads when using the :stdout reporter.

Without this change:

```
SendingSending  org/clojars/tcrawley/deploytest/0.1.3/deploytest-0.1.3.pom.sigorg/clojars/tcrawley/deploytest/0.1.3/deploytest-0.1.3.pom  (1k)(2k)Sending

Sending org/clojars/tcrawley/deploytest/0.1.3/deploytest-0.1.3.jar     to (9k)https://repo.clojars.org/

    toorg/clojars/tcrawley/deploytest/0.1.3/deploytest-0.1.3.jar.sig  https://repo.clojars.org/(1k)
    to
 https://repo.clojars.org/
    to https://repo.clojars.org/
Retrieving org/clojars/tcrawley/deploytest/maven-metadata.xml (1k)
    from https://repo.clojars.org/
Sending org/clojars/tcrawley/deploytest/maven-metadata.xml (1k)
    to https://repo.clojars.org/
```

With this change:

```
Sending org/clojars/tcrawley/deploytest/0.1.4/deploytest-0.1.4.jar.sig (1k)
    to https://repo.clojars.org/
Sending org/clojars/tcrawley/deploytest/0.1.4/deploytest-0.1.4.pom.sig (1k)
    to https://repo.clojars.org/
Sending org/clojars/tcrawley/deploytest/0.1.4/deploytest-0.1.4.pom (2k)
    to https://repo.clojars.org/
Sending org/clojars/tcrawley/deploytest/0.1.4/deploytest-0.1.4.jar (9k)
    to https://repo.clojars.org/
Retrieving org/clojars/tcrawley/deploytest/maven-metadata.xml (1k)
    from https://repo.clojars.org/
Sending org/clojars/tcrawley/deploytest/maven-metadata.xml (1k)
    to https://repo.clojars.org/
```